### PR TITLE
Po 865 get user state

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -300,6 +300,9 @@ dependencies {
   integrationTestCompileOnly 'org.projectlombok:lombok:1.18.34'
   integrationTestAnnotationProcessor 'org.projectlombok:lombok:1.18.34'
 
+  implementation 'org.mapstruct:mapstruct:1.6.3'
+  annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
+
 
   implementation group: 'org.apache.xmlgraphics', name: 'fop', version: '2.11'
   implementation group: 'org.apache.xmlgraphics', name: 'fop-core', version: '2.11'
@@ -311,7 +314,7 @@ dependencies {
   implementation(group: 'com.networknt', name: 'json-schema-validator', version: '1.5.8');
   implementation(group: 'com.jayway.jsonpath', name: 'json-path', version: '2.9.0');
   testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
-
+  testImplementation 'org.springframework.security:spring-security-test'
   testImplementation 'org.springframework.boot:spring-boot-devtools'
   testImplementation 'org.springframework.boot:spring-boot-testcontainers'
   testImplementation 'com.auth0:java-jwt:4.5.0'

--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/AbstractIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/AbstractIntegrationTest.java
@@ -1,0 +1,33 @@
+package uk.gov.hmcts.reform.opal;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static uk.gov.hmcts.reform.opal.TestContainerConfig.POSTGRES_CONTAINER;
+
+@SpringBootTest
+@ActiveProfiles("integration")
+@ContextConfiguration(classes = {TestContainerConfig.class})
+@AutoConfigureMockMvc(addFilters = true)
+public class AbstractIntegrationTest {
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    // Dynamically register properties to configure the datasource
+    @DynamicPropertySource
+    static void databaseProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES_CONTAINER::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES_CONTAINER::getUsername);
+        registry.add("spring.datasource.password", POSTGRES_CONTAINER::getPassword);
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/TestContainerConfig.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/TestContainerConfig.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.reform.opal;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@TestConfiguration
+public class TestContainerConfig {
+
+    public static final PostgreSQLContainer<?> POSTGRES_CONTAINER;
+
+    static {
+        POSTGRES_CONTAINER = new PostgreSQLContainer<>(DockerImageName.parse("postgres:17"))
+            .withDatabaseName("testdb")
+            .withUsername("test")
+            .withPassword("test");
+
+        POSTGRES_CONTAINER.start();
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/UserPermissionsControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/UserPermissionsControllerIntegrationTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.reform.opal.AbstractIntegrationTest;
@@ -18,27 +19,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @Sql(scripts = "classpath:db.insertData/insert_user_state_data.sql", executionPhase = BEFORE_TEST_CLASS)
+@TestPropertySource(properties = {"spring.jpa.hibernate.ddl-auto=create-drop"})
 @DisplayName("UserPermissionsController Integration Test with Security")
 class UserPermissionsControllerIntegrationTest extends AbstractIntegrationTest {
 
     private static final String URL_BASE = "/users";
-
-
-
-    @Test
-    @DisplayName("DEBUG: Print actual JSON response")
-    void debug_printActualResponse() throws Exception {
-        String response = mockMvc.perform(get(URL_BASE + "/500000000/state"))
-            .andExpect(status().isOk())
-            .andReturn().getResponse().getContentAsString();
-
-        System.out.println(response);
-        System.out.println("=== END RESPONSE ===");
-
-        var jsonNode = objectMapper.readTree(response);
-        System.out.println("=== PRETTY PRINTED ===");
-        System.out.println(objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonNode));
-    }
 
     @Test
     @DisplayName("Should return 200 and full user state for a user with permissions")

--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/UserPermissionsControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/UserPermissionsControllerIntegrationTest.java
@@ -1,0 +1,101 @@
+package uk.gov.hmcts.reform.opal.controllers;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.ResultActions;
+import uk.gov.hmcts.reform.opal.AbstractIntegrationTest;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_CLASS;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Sql(scripts = "classpath:db.insertData/insert_user_state_data.sql", executionPhase = BEFORE_TEST_CLASS)
+@DisplayName("UserPermissionsController Integration Test with Security")
+class UserPermissionsControllerIntegrationTest extends AbstractIntegrationTest {
+
+    private static final String URL_BASE = "/users";
+
+
+
+    @Test
+    @DisplayName("DEBUG: Print actual JSON response")
+    void debug_printActualResponse() throws Exception {
+        String response = mockMvc.perform(get(URL_BASE + "/500000000/state"))
+            .andExpect(status().isOk())
+            .andReturn().getResponse().getContentAsString();
+
+        System.out.println(response);
+        System.out.println("=== END RESPONSE ===");
+
+        var jsonNode = objectMapper.readTree(response);
+        System.out.println("=== PRETTY PRINTED ===");
+        System.out.println(objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonNode));
+    }
+
+    @Test
+    @DisplayName("Should return 200 and full user state for a user with permissions")
+    void getUserState_whenUserHasPermissions_returns200AndCorrectPayload() throws Exception {
+        long userIdWithPermissions = 500000000L;
+
+        ResultActions actions = mockMvc.perform(get(URL_BASE + "/" + userIdWithPermissions + "/state"));
+
+        actions.andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$['user_id']").value(500000000))
+            .andExpect(jsonPath("$['username']").value("opal-test@HMCTS.NET"))
+            .andExpect(jsonPath("$['business_unit_users']", hasSize(3)))
+            .andExpect(jsonPath("$['business_unit_users'][*]['business_unit_id']",
+                                containsInAnyOrder(70, 68, 61)))
+            .andExpect(jsonPath(
+                "$['business_unit_users'][?(@['business_unit_id']==70)]['business_unit_user_id']")
+                           .value("L065JG"))
+            .andExpect(jsonPath(
+                "$['business_unit_users'][?(@['business_unit_id']==70)]['permissions'][*]['permission_name']",
+                                containsInAnyOrder("Account Enquiry - Account Notes", "Account Enquiry")))
+            .andExpect(jsonPath(
+                "$['business_unit_users'][?(@['business_unit_id']==68)]['business_unit_user_id']")
+                           .value("L066JG"))
+            .andExpect(jsonPath(
+                "$['business_unit_users'][?(@['business_unit_id']==68)]['permissions'][0]['permission_name']")
+                           .value("Account Enquiry - Account Notes"))
+            .andExpect(jsonPath(
+                "$['business_unit_users'][?(@['business_unit_id']==61)]['business_unit_user_id']")
+                           .value("L080JG"))
+            .andExpect(jsonPath(
+                "$['business_unit_users'][?(@['business_unit_id']==61)]['permissions'][0]['permission_name']")
+                           .value("Collection Order"));
+    }
+
+    @Test
+    @DisplayName("Should return 200 and state with empty list for a user that exists but has no permissions")
+    void getUserState_whenUserExistsButHasNoPermissions_returns200AndEmptyList() throws Exception {
+        long userIdWithoutPermissions = 500000001L;
+
+        ResultActions actions = mockMvc.perform(get(URL_BASE + "/" + userIdWithoutPermissions + "/state"));
+
+        actions.andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$['user_id']").value(500000001))
+            .andExpect(jsonPath("$['username']").value("opal-test-2@HMCTS.NET"))
+            .andExpect(jsonPath("$['business_unit_users']", hasSize(0)));
+    }
+
+    @Test
+    @DisplayName("Should return 404 Not Found for a user that does not exist")
+    void getUserState_whenUserDoesNotExist_returns404() throws Exception {
+        long nonExistentUserId = 999999999L;
+
+        mockMvc.perform(get(URL_BASE + "/" + nonExistentUserId + "/state"))
+            .andExpect(status().isNotFound());
+    }
+
+
+}

--- a/src/integrationTest/resources/application-integration.yaml
+++ b/src/integrationTest/resources/application-integration.yaml
@@ -6,6 +6,10 @@ spring:
       resourceserver:
         jwt:
           jwk-set-uri: false
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
 
   autoconfigure:
     exclude:

--- a/src/integrationTest/resources/application-integration.yaml
+++ b/src/integrationTest/resources/application-integration.yaml
@@ -6,10 +6,6 @@ spring:
       resourceserver:
         jwt:
           jwk-set-uri: false
-  jpa:
-    hibernate:
-      ddl-auto: create-drop
-    show-sql: true
 
   autoconfigure:
     exclude:

--- a/src/integrationTest/resources/db.insertData/insert_user_state_data.sql
+++ b/src/integrationTest/resources/db.insertData/insert_user_state_data.sql
@@ -1,0 +1,42 @@
+-- Insert users from Flyway script V20240729_003
+INSERT INTO users (user_id, username, password, description)
+VALUES (500000000, 'opal-test@HMCTS.NET', 'password', 'User with 7 business units');
+
+INSERT INTO users (user_id, username, password, description)
+VALUES (500000001, 'opal-test-2@HMCTS.NET', NULL, 'User with no business units');
+
+-- Insert business units that are referenced in the business_unit_users script
+INSERT INTO business_units (business_unit_id, business_unit_name, business_unit_code, business_unit_type)
+VALUES (61, 'Test BU 61', 'T61', 'TEST'),
+       (67, 'Test BU 67', 'T67', 'TEST'),
+       (68, 'Test BU 68', 'T68', 'TEST'),
+       (69, 'Test BU 69', 'T69', 'TEST'),
+       (70, 'Test BU 70', 'T70', 'TEST'),
+       (71, 'Test BU 71', 'T71', 'TEST'),
+       (73, 'Test BU 73', 'T73', 'TEST');
+
+
+-- Insert application functions (permissions) from Flyway script V20240730_006
+INSERT INTO application_functions (application_function_id, function_name)
+VALUES (35, 'Manual Account Creation'),
+       (41, 'Account Enquiry - Account Notes'),
+       (54, 'Account Enquiry'),
+       (500, 'Collection Order');
+
+-- Link User 500000000 to Business Units from Flyway script V20240730_005
+INSERT INTO business_unit_users (business_unit_user_id, business_unit_id, user_id)
+VALUES ('L065JG', 70, 500000000),
+       ('L066JG', 68, 500000000),
+       ('L067JG', 73, 500000000),
+       ('L073JG', 71, 500000000),
+       ('L077JG', 67, 500000000),
+       ('L078JG', 69, 500000000),
+       ('L080JG', 61, 500000000);
+
+-- Grant permissions to User 500000000 from Flyway script V20240730_007
+-- Granting a subset for a focused test
+INSERT INTO user_entitlements (user_entitlement_id, business_unit_user_id, application_function_id)
+VALUES (112687, 'L065JG', 41), -- BU 70 gets 'Account Enquiry - Account Notes'
+       (112683, 'L065JG', 54), -- BU 70 gets 'Account Enquiry'
+       (112921, 'L066JG', 41), -- BU 68 gets 'Account Enquiry - Account Notes'
+       (500001, 'L080JG', 500); -- BU 61 gets 'Collection Order'

--- a/src/main/java/uk/gov/hmcts/reform/opal/controllers/UserPermissionsController.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/controllers/UserPermissionsController.java
@@ -1,0 +1,73 @@
+package uk.gov.hmcts.reform.opal.controllers;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.hmcts.reform.opal.dto.UserStateDto;
+import uk.gov.hmcts.reform.opal.service.UserPermissionsService;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+@Slf4j(topic = "opal.UserPermissionsController")
+public class UserPermissionsController {
+
+
+    //The name claim of the authorised user.
+    private static final String NAME_CLAIM = "name";
+
+    //The claim used to map the authorised user to the user entity.
+    private static final String AUTHORISED_USER_CLAIM = "preferred_username";
+
+    private final UserPermissionsService userPermissionsService;
+
+    @GetMapping("/{userId}/state")
+    public ResponseEntity<UserStateDto> getUserState(
+        @PathVariable Long userId,
+        Authentication authentication) {
+
+        log.debug(":GET:getUserState: userId: {}", userId);
+
+        UserStateDto userStateDto;
+
+        if (userId == 0) {
+
+            String username = extractClaimAsString(authentication, AUTHORISED_USER_CLAIM);
+            String name = extractClaimAsString(authentication, NAME_CLAIM);
+
+            log.debug(":GET:getUserState: userId is 0, using username: {}", username);
+
+            userStateDto = userPermissionsService.getUserState(username);
+            userStateDto.setName(name);
+
+
+        } else {
+            userStateDto = userPermissionsService.getUserState(userId);
+        }
+
+        return ResponseEntity.ok(userStateDto);
+    }
+
+    private String extractClaimAsString(Authentication authentication, String claimName) {
+        if (authentication instanceof JwtAuthenticationToken jwtAuth) {
+            Jwt jwt = jwtAuth.getToken();
+            String claimValue = jwt.getClaimAsString(claimName);
+            if (claimValue != null) {
+                return claimValue;
+            } else {
+                throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Claim not found: " + claimName);
+            }
+        }
+        throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Claim not found: " + claimName);
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/opal/controllers/advice/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/controllers/advice/GlobalExceptionHandler.java
@@ -44,6 +44,7 @@ public class GlobalExceptionHandler {
 
     public static final String DB_UNAVAILABLE_MESSAGE = "Opal Fines Database is currently unavailable";
     public static final String UNKNOWN = "'Unknown'";
+    public static final String INTERNAL_SERVER_ERROR = "Internal Server Error";
 
 
     @ExceptionHandler(HttpMediaTypeNotAcceptableException.class)
@@ -129,7 +130,7 @@ public class GlobalExceptionHandler {
 
         ProblemDetail problemDetail = createProblemDetail(
             HttpStatus.INTERNAL_SERVER_ERROR,
-            "Internal Server Error",
+            INTERNAL_SERVER_ERROR,
             "A problem occurred while accessing data",
             "invalid-data-access",
             idaaue
@@ -144,7 +145,7 @@ public class GlobalExceptionHandler {
 
         ProblemDetail problemDetail = createProblemDetail(
             HttpStatus.INTERNAL_SERVER_ERROR,
-            "Internal Server Error",
+            INTERNAL_SERVER_ERROR,
             "A problem occurred with the requested data resource",
             "invalid-resource-usage",
             idarue
@@ -229,7 +230,7 @@ public class GlobalExceptionHandler {
 
         ProblemDetail problemDetail = createProblemDetail(
             HttpStatus.INTERNAL_SERVER_ERROR,
-            "Internal Server Error",
+            INTERNAL_SERVER_ERROR,
             "An unexpected error occurred while processing your request",
             "servlet-error",
             ex
@@ -256,7 +257,7 @@ public class GlobalExceptionHandler {
 
         ProblemDetail problemDetail = createProblemDetail(
             HttpStatus.INTERNAL_SERVER_ERROR,
-            "Internal Server Error",
+            INTERNAL_SERVER_ERROR,
             "A database error occurred while processing your request",
             "database-error",
             psqlException
@@ -286,7 +287,7 @@ public class GlobalExceptionHandler {
 
         ProblemDetail problemDetail = createProblemDetail(
             HttpStatus.INTERNAL_SERVER_ERROR,
-            "Internal Server Error",
+            INTERNAL_SERVER_ERROR,
             "A data access error occurred.",
             "lazy-initialization",
             lazyInitializationException
@@ -299,7 +300,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ProblemDetail> handleJpaSystemException(JpaSystemException jpaSystemException) {
         ProblemDetail problemDetail = createProblemDetail(
             HttpStatus.INTERNAL_SERVER_ERROR,
-            "Internal Server Error",
+            INTERNAL_SERVER_ERROR,
             "A persistence error occurred while processing your request",
             "jpa-system-error",
             jpaSystemException
@@ -356,10 +357,6 @@ public class GlobalExceptionHandler {
         problemDetail.setProperty("conflictReason", e.getConflictReason());
 
         return responseWithProblemDetail(HttpStatus.CONFLICT, problemDetail);
-    }
-
-    private Throwable getNonNullCause(Throwable t) {
-        return t.getCause() == null ? t : t.getCause();
     }
 
     private ProblemDetail createProblemDetail(HttpStatus status, String title, String detail,

--- a/src/main/java/uk/gov/hmcts/reform/opal/controllers/advice/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/controllers/advice/GlobalExceptionHandler.java
@@ -1,0 +1,386 @@
+package uk.gov.hmcts.reform.opal.controllers.advice;
+
+
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.persistence.PersistenceException;
+import jakarta.persistence.QueryTimeoutException;
+import jakarta.servlet.ServletException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.LazyInitializationException;
+import org.hibernate.PropertyValueException;
+import org.postgresql.util.PSQLException;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.dao.InvalidDataAccessResourceUsageException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.orm.jpa.JpaSystemException;
+import org.springframework.transaction.TransactionSystemException;
+import org.springframework.web.HttpMediaTypeNotAcceptableException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+import uk.gov.hmcts.reform.opal.exception.OpalApiException;
+import uk.gov.hmcts.reform.opal.exception.ResourceConflictException;
+
+import java.net.ConnectException;
+import java.net.URI;
+import java.net.UnknownHostException;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j(topic = "opal.GlobalExceptionHandler")
+@ControllerAdvice
+@RequiredArgsConstructor
+public class GlobalExceptionHandler {
+
+    public static final String DB_UNAVAILABLE_MESSAGE = "Opal Fines Database is currently unavailable";
+    public static final String UNKNOWN = "'Unknown'";
+
+
+    @ExceptionHandler(HttpMediaTypeNotAcceptableException.class)
+    public ResponseEntity<ProblemDetail> handleHttpMediaTypeNotAcceptableException(
+        HttpMediaTypeNotAcceptableException ex) {
+
+        ProblemDetail problemDetail = createProblemDetail(
+            HttpStatus.NOT_ACCEPTABLE,
+            "Not Acceptable",
+            "The requested media type cannot be produced by the server",
+            "not-acceptable",
+            ex
+        );
+
+        return responseWithProblemDetail(HttpStatus.NOT_ACCEPTABLE, problemDetail);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ProblemDetail> handleMethodArgumentTypeMismatchException(
+        MethodArgumentTypeMismatchException ex) {
+
+        ProblemDetail problemDetail = createProblemDetail(
+            HttpStatus.NOT_ACCEPTABLE,
+            "Not Acceptable",
+            "Invalid parameter value format",
+            "type-mismatch",
+            ex
+        );
+
+        return responseWithProblemDetail(HttpStatus.NOT_ACCEPTABLE, problemDetail);
+    }
+
+    @ExceptionHandler(PropertyValueException.class)
+    public ResponseEntity<ProblemDetail> handlePropertyValueException(PropertyValueException pve) {
+        ProblemDetail problemDetail = createProblemDetail(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "Property Value Error",
+            "Invalid or missing value for a required property",
+            "property-value-error",
+            pve
+        );
+
+        // Add additional properties to the problem detail
+        problemDetail.setProperty("entity", pve.getEntityName());
+        problemDetail.setProperty("property", pve.getPropertyName());
+
+        return responseWithProblemDetail(HttpStatus.INTERNAL_SERVER_ERROR, problemDetail);
+    }
+
+    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+    public ResponseEntity<ProblemDetail> handleHttpMediaTypeNotSupportedException(
+        HttpMediaTypeNotSupportedException ex) {
+
+        ProblemDetail problemDetail = createProblemDetail(
+            HttpStatus.UNSUPPORTED_MEDIA_TYPE,
+            "Unsupported Media Type",
+            "The Content-Type is not supported. Please use application/json",
+            "unsupported-media-type",
+            ex
+        );
+
+        return responseWithProblemDetail(HttpStatus.UNSUPPORTED_MEDIA_TYPE, problemDetail);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ProblemDetail> handleHttpMessageNotReadableException(
+        HttpMessageNotReadableException ex) {
+
+        ProblemDetail problemDetail = createProblemDetail(
+            HttpStatus.BAD_REQUEST,
+            "Bad Request",
+            "The request body could not be read. It may be missing or invalid JSON.",
+            "message-not-readable",
+            ex
+        );
+
+        return responseWithProblemDetail(HttpStatus.BAD_REQUEST, problemDetail);
+    }
+
+    @ExceptionHandler(InvalidDataAccessApiUsageException.class)
+    public ResponseEntity<ProblemDetail> handleInvalidDataAccessApiUsageException(
+        InvalidDataAccessApiUsageException idaaue) {
+
+        ProblemDetail problemDetail = createProblemDetail(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "Internal Server Error",
+            "A problem occurred while accessing data",
+            "invalid-data-access",
+            idaaue
+        );
+
+        return responseWithProblemDetail(HttpStatus.INTERNAL_SERVER_ERROR, problemDetail);
+    }
+
+    @ExceptionHandler(InvalidDataAccessResourceUsageException.class)
+    public ResponseEntity<ProblemDetail> handleInvalidDataAccessResourceUsageException(
+        InvalidDataAccessResourceUsageException idarue) {
+
+        ProblemDetail problemDetail = createProblemDetail(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "Internal Server Error",
+            "A problem occurred with the requested data resource",
+            "invalid-resource-usage",
+            idarue
+        );
+
+        return responseWithProblemDetail(HttpStatus.INTERNAL_SERVER_ERROR, problemDetail);
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<ProblemDetail> handleEntityNotFoundException(
+        EntityNotFoundException entityNotFoundException) {
+
+        ProblemDetail problemDetail = createProblemDetail(
+            HttpStatus.NOT_FOUND,
+            "Entity Not Found",
+            "The requested entity could not be found",
+            "entity-not-found",
+            entityNotFoundException
+        );
+
+        return responseWithProblemDetail(HttpStatus.NOT_FOUND, problemDetail);
+    }
+
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<ProblemDetail> handleNoSuchElementException(
+        NoSuchElementException noSuchElementException) {
+
+        ProblemDetail problemDetail = createProblemDetail(
+            HttpStatus.NOT_FOUND,
+            "No Value Present",
+            "The requested element does not exist",
+            "no-such-element",
+            noSuchElementException
+        );
+
+        return responseWithProblemDetail(HttpStatus.NOT_FOUND, problemDetail);
+    }
+
+    @ExceptionHandler(OpalApiException.class)
+    public ResponseEntity<ProblemDetail> handleOpalApiException(
+        OpalApiException opalApiException) {
+
+        HttpStatus status = opalApiException.getError().getHttpStatus();
+
+        ProblemDetail problemDetail = createProblemDetail(
+            status,
+            status.getReasonPhrase(),
+            "An error occurred while processing your request",
+            "opal-api-error",
+            opalApiException
+        );
+
+        return responseWithProblemDetail(status, problemDetail);
+    }
+
+    @ExceptionHandler({ServletException.class, TransactionSystemException.class, PersistenceException.class})
+    public ResponseEntity<ProblemDetail> handleServletExceptions(Exception ex) {
+
+        if (ex instanceof QueryTimeoutException) {
+            ProblemDetail problemDetail = createProblemDetail(
+                HttpStatus.REQUEST_TIMEOUT,
+                "Request Timeout",
+                "The request did not receive a response from the database within the timeout period",
+                "query-timeout",
+                ex
+            );
+
+            return responseWithProblemDetail(HttpStatus.REQUEST_TIMEOUT, problemDetail);
+        }
+
+        if (ex instanceof NoResourceFoundException nrfe) {
+            ProblemDetail problemDetail = createProblemDetail(
+                HttpStatus.NOT_FOUND,
+                "Not Found",
+                "The requested resource could not be found",
+                "resource-not-found",
+                nrfe
+            );
+
+            return responseWithProblemDetail(HttpStatus.NOT_FOUND, problemDetail);
+        }
+
+        ProblemDetail problemDetail = createProblemDetail(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "Internal Server Error",
+            "An unexpected error occurred while processing your request",
+            "servlet-error",
+            ex
+        );
+
+        return responseWithProblemDetail(HttpStatus.INTERNAL_SERVER_ERROR, problemDetail);
+    }
+
+    @ExceptionHandler(PSQLException.class)
+    public ResponseEntity<ProblemDetail> handlePsqlException(PSQLException psqlException) {
+        if (psqlException.getCause() instanceof ConnectException
+            || psqlException.getCause() instanceof UnknownHostException) {
+
+            ProblemDetail problemDetail = createProblemDetail(
+                HttpStatus.SERVICE_UNAVAILABLE,
+                "Service Unavailable",
+                DB_UNAVAILABLE_MESSAGE,
+                "database-unavailable",
+                psqlException
+            );
+
+            return responseWithProblemDetail(HttpStatus.SERVICE_UNAVAILABLE, problemDetail);
+        }
+
+        ProblemDetail problemDetail = createProblemDetail(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "Internal Server Error",
+            "A database error occurred while processing your request",
+            "database-error",
+            psqlException
+        );
+
+        return responseWithProblemDetail(HttpStatus.INTERNAL_SERVER_ERROR, problemDetail);
+    }
+
+    @ExceptionHandler(DataAccessResourceFailureException.class)
+    public ResponseEntity<ProblemDetail> handleDataAccessResourceFailureException(
+        DataAccessResourceFailureException dataAccessResourceFailureException) {
+
+        ProblemDetail problemDetail = createProblemDetail(
+            HttpStatus.SERVICE_UNAVAILABLE,
+            "Service Unavailable",
+            DB_UNAVAILABLE_MESSAGE,
+            "database-unavailable",
+            dataAccessResourceFailureException
+        );
+
+        return responseWithProblemDetail(HttpStatus.SERVICE_UNAVAILABLE, problemDetail);
+    }
+
+    @ExceptionHandler(LazyInitializationException.class)
+    public ResponseEntity<ProblemDetail> handleLazyInitializationException(
+        LazyInitializationException lazyInitializationException) {
+
+        ProblemDetail problemDetail = createProblemDetail(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "Internal Server Error",
+            "A data access error occurred.",
+            "lazy-initialization",
+            lazyInitializationException
+        );
+
+        return responseWithProblemDetail(HttpStatus.INTERNAL_SERVER_ERROR, problemDetail);
+    }
+
+    @ExceptionHandler(JpaSystemException.class)
+    public ResponseEntity<ProblemDetail> handleJpaSystemException(JpaSystemException jpaSystemException) {
+        ProblemDetail problemDetail = createProblemDetail(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "Internal Server Error",
+            "A persistence error occurred while processing your request",
+            "jpa-system-error",
+            jpaSystemException
+        );
+
+        return responseWithProblemDetail(HttpStatus.INTERNAL_SERVER_ERROR, problemDetail);
+    }
+
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ProblemDetail> handleIllegalArgumentException(IllegalArgumentException e) {
+        ProblemDetail problemDetail = createProblemDetail(
+            HttpStatus.BAD_REQUEST,
+            "Bad Request",
+            "Invalid arguments were provided in the request",
+            "illegal-argument",
+            e
+        );
+
+        return responseWithProblemDetail(HttpStatus.BAD_REQUEST, problemDetail);
+    }
+
+    @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
+    public ResponseEntity<ProblemDetail> handleObjectOptimisticLockingFailureException(
+        ObjectOptimisticLockingFailureException e) {
+
+        ProblemDetail problemDetail = createProblemDetail(
+            HttpStatus.CONFLICT,
+            "Conflict",
+            "Conflict updating record. Please try again.",
+            "optimistic-locking",
+            e
+        );
+
+        problemDetail.setProperty("resourceType", e.getPersistentClassName());
+        problemDetail.setProperty("resourceId",
+                                  Optional.ofNullable(e.getIdentifier()).map(Object::toString).orElse(""));
+
+        return responseWithProblemDetail(HttpStatus.CONFLICT, problemDetail);
+    }
+
+    @ExceptionHandler(ResourceConflictException.class)
+    public ResponseEntity<ProblemDetail> handleResourceConflictException(ResourceConflictException e) {
+        ProblemDetail problemDetail = createProblemDetail(
+            HttpStatus.CONFLICT,
+            "Conflict",
+            "A conflict occurred with the requested resource",
+            "resource-conflict",
+            e
+        );
+
+        problemDetail.setProperty("resourceType", e.getResourceType());
+        problemDetail.setProperty("resourceId", e.getResourceId());
+        problemDetail.setProperty("conflictReason", e.getConflictReason());
+
+        return responseWithProblemDetail(HttpStatus.CONFLICT, problemDetail);
+    }
+
+    private Throwable getNonNullCause(Throwable t) {
+        return t.getCause() == null ? t : t.getCause();
+    }
+
+    private ProblemDetail createProblemDetail(HttpStatus status, String title, String detail,
+                                              String typeUri, Throwable exception) {
+        String errorId = UUID.randomUUID().toString();
+
+        log.error("Error ID {}: {}", errorId, exception.getMessage());
+        log.error("Error ID {}:", errorId, exception);
+
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(status, detail);
+        problemDetail.setTitle(title);
+        problemDetail.setType(URI.create("https://hmcts.gov.uk/problems/" + typeUri));
+        problemDetail.setInstance(URI.create("https://hmcts.gov.uk/problems/instance/" + errorId));
+
+        return problemDetail;
+    }
+
+    private ResponseEntity<ProblemDetail> responseWithProblemDetail(HttpStatus status, ProblemDetail problemDetail) {
+        return ResponseEntity.status(status)
+            .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+            .body(problemDetail);
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/opal/dto/BusinessUnitUserDto.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/dto/BusinessUnitUserDto.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.reform.opal.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BusinessUnitUserDto {
+
+    @JsonProperty("business_unit_user_id")
+    private String businessUnitUserId;
+
+    @JsonProperty("business_unit_id")
+    private Short businessUnitId;
+
+    @JsonProperty("permissions")
+    private List<PermissionDto> permissions;
+}

--- a/src/main/java/uk/gov/hmcts/reform/opal/dto/PermissionDto.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/dto/PermissionDto.java
@@ -1,0 +1,18 @@
+package uk.gov.hmcts.reform.opal.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PermissionDto {
+
+    @JsonProperty("permission_id")
+    private Long permissionId;
+
+    @JsonProperty("permission_name")
+    private String permissionName;
+}

--- a/src/main/java/uk/gov/hmcts/reform/opal/dto/UserStateDto.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/dto/UserStateDto.java
@@ -1,0 +1,35 @@
+package uk.gov.hmcts.reform.opal.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserStateDto {
+
+    @JsonProperty("user_id")
+    private Long userId;
+
+    //users.username
+    @JsonProperty("username")
+    private String username;
+
+    //Obtained from the Access Token (via Spring Security) until stored in the Database under
+    // TDIA: User Service - Matching Key and JIT Provisioning, and only applies when id is 0 (zero) until then.
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("status")
+    private String status;
+
+    @JsonProperty("version")
+    private Integer version;
+
+    @JsonProperty("business_unit_users")
+    private List<BusinessUnitUserDto> businessUnitUsers;
+}

--- a/src/main/java/uk/gov/hmcts/reform/opal/entity/BusinessUnitUserEntity.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/entity/BusinessUnitUserEntity.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.opal.entity;
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -37,12 +36,12 @@ public class BusinessUnitUserEntity {
     @Column(name = "business_unit_user_id", length = 6)
     private String businessUnitUserId;
 
-    @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "business_unit_id", nullable = false)
     @EqualsAndHashCode.Exclude
     private BusinessUnitEntity businessUnit;
 
-    @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     @EqualsAndHashCode.Exclude
     private UserEntity user;

--- a/src/main/java/uk/gov/hmcts/reform/opal/entity/UserEntitlementEntity.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/entity/UserEntitlementEntity.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.opal.entity;
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -44,12 +43,12 @@ public class UserEntitlementEntity {
     @Column(name = "user_entitlement_id")
     private Long userEntitlementId;
 
-    @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "business_unit_user_id", nullable = false)
     @EqualsAndHashCode.Exclude
     private BusinessUnitUserEntity businessUnitUser;
 
-    @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "application_function_id", nullable = false)
     @EqualsAndHashCode.Exclude
     private ApplicationFunctionEntity applicationFunction;

--- a/src/main/java/uk/gov/hmcts/reform/opal/exception/ResourceConflictException.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/exception/ResourceConflictException.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.reform.opal.exception;
+
+import lombok.Getter;
+
+import java.util.Optional;
+
+@Getter
+public class ResourceConflictException extends RuntimeException {
+
+    private final String resourceType;
+    private final String resourceId;
+    private final String conflictReason;
+
+    public ResourceConflictException(String resourceType, Object resourceId, String conflictReason) {
+        this.resourceType = resourceType;
+        this.resourceId = Optional.ofNullable(resourceId).map(Object::toString).orElse("<null>");
+        this.conflictReason = conflictReason;
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/opal/mappers/UserStateMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/mappers/UserStateMapper.java
@@ -1,0 +1,45 @@
+package uk.gov.hmcts.reform.opal.mappers;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import uk.gov.hmcts.reform.opal.dto.BusinessUnitUserDto;
+import uk.gov.hmcts.reform.opal.dto.PermissionDto;
+import uk.gov.hmcts.reform.opal.dto.UserStateDto;
+import uk.gov.hmcts.reform.opal.entity.BusinessUnitUserEntity;
+import uk.gov.hmcts.reform.opal.entity.UserEntitlementEntity;
+import uk.gov.hmcts.reform.opal.entity.UserEntity;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface UserStateMapper {
+
+    /**
+     * Main mapping method to build the complete UserStateDto.
+     * The service now provides a pre-built list of BusinessUnitUserDto objects.
+     */
+    @Mapping(source = "userEntity.userId", target = "userId")
+    @Mapping(source = "userEntity.username", target = "username")
+    @Mapping(source = "businessUnitUsers", target = "businessUnitUsers")
+    @Mapping(target = "name", ignore = true)
+    @Mapping(target = "status", ignore = true)
+    @Mapping(target = "version", ignore = true)
+    UserStateDto toUserStateDto(UserEntity userEntity, List<BusinessUnitUserDto> businessUnitUsers);
+
+    /**
+     * Helper method called by the service to map a BusinessUnitUserEntity and its associated
+     * list of entitlements into a BusinessUnitUserDto.
+     */
+    @Mapping(source = "businessUnitUser.businessUnitUserId", target = "businessUnitUserId")
+    @Mapping(source = "businessUnitUser.businessUnitId", target = "businessUnitId")
+    @Mapping(source = "entitlements", target = "permissions")
+    BusinessUnitUserDto toBusinessUnitUserDto(BusinessUnitUserEntity businessUnitUser,
+                                              List<UserEntitlementEntity> entitlements);
+
+    /**
+     * Helper method to map a UserEntitlementEntity to a PermissionDto.
+     */
+    @Mapping(source = "applicationFunction.applicationFunctionId", target = "permissionId")
+    @Mapping(source = "applicationFunction.functionName", target = "permissionName")
+    PermissionDto toPermissionDto(UserEntitlementEntity entitlementEntity);
+}

--- a/src/main/java/uk/gov/hmcts/reform/opal/mappers/UserStateMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/mappers/UserStateMapper.java
@@ -21,9 +21,9 @@ public interface UserStateMapper {
     @Mapping(source = "userEntity.userId", target = "userId")
     @Mapping(source = "userEntity.username", target = "username")
     @Mapping(source = "businessUnitUsers", target = "businessUnitUsers")
-    @Mapping(target = "name", ignore = true)
-    @Mapping(target = "status", ignore = true)
-    @Mapping(target = "version", ignore = true)
+    @Mapping(target = "name", ignore = true) // Name is not in db yet, get from auth till we have it in db
+    @Mapping(target = "status", ignore = true)//status is not in db yet, placeholder for future use
+    @Mapping(target = "version", ignore = true)//version is not in db yet, placeholder for future use
     UserStateDto toUserStateDto(UserEntity userEntity, List<BusinessUnitUserDto> businessUnitUsers);
 
     /**

--- a/src/main/java/uk/gov/hmcts/reform/opal/repository/UserEntitlementRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/repository/UserEntitlementRepository.java
@@ -2,15 +2,31 @@ package uk.gov.hmcts.reform.opal.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import uk.gov.hmcts.reform.opal.entity.UserEntitlementEntity;
 
 import java.util.List;
+import java.util.Set;
 
 @Repository
 public interface UserEntitlementRepository extends JpaRepository<UserEntitlementEntity, Long>,
     JpaSpecificationExecutor<UserEntitlementEntity> {
 
     List<UserEntitlementEntity> findAllByBusinessUnitUser_BusinessUnitUserId(String businessUnitUserId);
+
+    /**
+     * Finds all entitlements for a given userId.Eagerly fetches all parent objects
+     * (the business unit user, the user itself, the business unit, and the function name)
+     * in a single query to avoid the N+1 problem.
+     */
+    @Query("""
+        SELECT DISTINCT ue FROM UserEntitlementEntity ue
+        JOIN FETCH ue.applicationFunction
+        JOIN FETCH ue.businessUnitUser buu
+        JOIN FETCH buu.businessUnit
+        JOIN FETCH buu.user u
+        WHERE u.userId = :userId""")
+    Set<UserEntitlementEntity> findAllByUserIdWithFullJoins(Long userId);
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/opal/repository/UserRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/repository/UserRepository.java
@@ -5,9 +5,15 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 import uk.gov.hmcts.reform.opal.entity.UserEntity;
 
+import java.util.Optional;
+
 @Repository
-public interface UserRepository extends JpaRepository<UserEntity, String>,
+public interface UserRepository extends JpaRepository<UserEntity, Long>,
     JpaSpecificationExecutor<UserEntity> {
 
     UserEntity findByUsername(String username);
+
+    Optional<UserEntity> findOptionalByUsername(String username);
+
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/opal/service/UserPermissionsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/service/UserPermissionsService.java
@@ -1,0 +1,77 @@
+package uk.gov.hmcts.reform.opal.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.opal.dto.BusinessUnitUserDto;
+import uk.gov.hmcts.reform.opal.dto.UserStateDto;
+import uk.gov.hmcts.reform.opal.entity.BusinessUnitUserEntity;
+import uk.gov.hmcts.reform.opal.entity.UserEntitlementEntity;
+import uk.gov.hmcts.reform.opal.entity.UserEntity;
+import uk.gov.hmcts.reform.opal.mappers.UserStateMapper;
+import uk.gov.hmcts.reform.opal.repository.UserEntitlementRepository;
+import uk.gov.hmcts.reform.opal.repository.UserRepository;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+
+@Service
+@RequiredArgsConstructor
+public class UserPermissionsService {
+
+    private final UserEntitlementRepository userEntitlementRepository;
+    private final UserRepository userRepository;
+    private final UserStateMapper userStateMapper;
+
+    public UserStateDto getUserState(Long userId) {
+
+        // 1. Get all entitlements for the user.
+        Set<UserEntitlementEntity> entitlements = userEntitlementRepository.findAllByUserIdWithFullJoins(userId);
+
+        // 2. If the set is empty, check if the user actually exists.
+        if (entitlements.isEmpty()) {
+            UserEntity userEntity = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("User not found with ID: " + userId));
+            // User exists but has no entitlements, so return the DTO with an empty list.
+            return userStateMapper.toUserStateDto(userEntity, Collections.emptyList());
+        }
+
+        // 3. Get the UserEntity from an arbitrary element in the set.
+        UserEntity userEntity = entitlements.iterator().next().getBusinessUnitUser().getUser();
+
+        // 4. Group entitlements by the BusinessUnitUser's ID (a String)
+        Map<String, List<UserEntitlementEntity>> entitlementsByBuuId = entitlements.stream()
+            .collect(Collectors.groupingBy(UserEntitlementEntity::getBusinessUnitUserId));
+
+        // 5. Create a map of the BusinessUnitUserEntity objects, keyed by their ID.
+        Map<String, BusinessUnitUserEntity> buuMap = entitlements.stream()
+            .map(UserEntitlementEntity::getBusinessUnitUser)
+            .distinct()
+            .collect(Collectors.toMap(BusinessUnitUserEntity::getBusinessUnitUserId, Function.identity()));
+
+        // 6. Build the list of BusinessUnitUserDto objects.
+        List<BusinessUnitUserDto> buuDtos = buuMap.values().stream()
+            .map(buu -> {
+                List<UserEntitlementEntity> buuEntitlements = entitlementsByBuuId.get(buu.getBusinessUnitUserId());
+                return userStateMapper.toBusinessUnitUserDto(buu, buuEntitlements);
+            })
+            .collect(Collectors.toList());
+
+        // 7. Pass the user entity and the BUU list to the mapper.
+        return userStateMapper.toUserStateDto(userEntity, buuDtos);
+    }
+
+    public UserStateDto getUserState(String username) {
+
+        UserEntity userEntity = userRepository.findOptionalByUsername(username)
+            .orElseThrow(() -> new EntityNotFoundException("User not found with username: " + username));
+
+        return this.getUserState(userEntity.getUserId());
+
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/opal/service/UserPermissionsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/service/UserPermissionsService.java
@@ -60,7 +60,7 @@ public class UserPermissionsService {
                 List<UserEntitlementEntity> buuEntitlements = entitlementsByBuuId.get(buu.getBusinessUnitUserId());
                 return userStateMapper.toBusinessUnitUserDto(buu, buuEntitlements);
             })
-            .collect(Collectors.toList());
+            .toList();
 
         // 7. Pass the user entity and the BUU list to the mapper.
         return userStateMapper.toUserStateDto(userEntity, buuDtos);

--- a/src/main/java/uk/gov/hmcts/reform/opal/service/opal/UserService.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/service/opal/UserService.java
@@ -32,7 +32,7 @@ public class UserService implements UserServiceInterface {
 
     @Override
     public UserEntity getUser(String userId) {
-        return userRepository.getReferenceById(userId);
+        return userRepository.getReferenceById(Long.valueOf(userId));
     }
 
     @Override

--- a/src/main/resources/jsonSchemas/getUserStateResponse.json
+++ b/src/main/resources/jsonSchemas/getUserStateResponse.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Get User State Response",
+  "description": "The complete state for a given user, including primary details and permissions per business unit.",
+  "type": "object",
+  "properties": {
+    "user_id": {
+      "type": "integer",
+      "description": "The user's unique identifier."
+    },
+    "username": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string",
+      "description": "Obtained from the Access Token."
+    },
+    "status": {
+      "type": "string",
+      "description": "The user's status."
+    },
+    "version": {
+      "type": "integer",
+      "description": "The version of the user object."
+    },
+    "business_unit_users": {
+      "type": "array",
+      "minItems": 0,
+      "items": {
+        "$ref": "#/definitions/BusinessUnitUser"
+      }
+    }
+  },
+  "required": [
+    "user_id",
+    "username",
+    "status",
+    "version"
+  ],
+  "definitions": {
+    "BusinessUnitUser": {
+      "type": "object",
+      "description": "Defines a user's role and permissions within a specific Business Unit.",
+      "properties": {
+        "business_unit_user_id": {
+          "type": "string",
+          "description": "The unique identifier for the business unit user relationship."
+        },
+        "business_unit_id": {
+          "type": "integer",
+          "description": "The unique identifier for the business unit."
+        },
+        "permissions": {
+          "type": "array",
+          "minItems": 0,
+          "description": "An array of permissions for the user within this business unit.",
+          "items": {
+            "$ref": "#/definitions/Permission"
+          }
+        }
+      },
+      "required": [
+        "business_unit_user_id",
+        "business_unit_id"
+      ]
+    },
+    "Permission": {
+      "type": "object",
+      "description": "Defines a specific permission.",
+      "properties": {
+        "permission_id": {
+          "type": "integer",
+          "description": "The unique identifier for the permission."
+        },
+        "permission_name": {
+          "type": "string",
+          "description": "The name of the permission."
+        }
+      },
+      "required": [
+        "permission_id",
+        "permission_name"
+      ]
+    }
+  }
+}

--- a/src/test/java/uk/gov/hmcts/reform/opal/controllers/UserPermissionsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/opal/controllers/UserPermissionsControllerTest.java
@@ -1,0 +1,65 @@
+package uk.gov.hmcts.reform.opal.controllers;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import uk.gov.hmcts.reform.opal.dto.UserStateDto;
+import uk.gov.hmcts.reform.opal.service.UserPermissionsService;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class UserPermissionsControllerTest {
+
+    @Mock
+    private UserPermissionsService userPermissionsService;
+
+    @InjectMocks
+    private UserPermissionsController controller;
+
+    @BeforeEach
+    void setup() {
+        // no additional setup
+    }
+
+    @Test
+    @DisplayName("getUserState with userId=0 uses principal name with preferred_username claim")
+    void getUserState_whenUserIdZero_invokesServiceWithPreferredUsernameClaim() {
+        // Arrange
+        String expectedUsername = "opal-test@HMCTS.NET";
+        UserStateDto returnedDto = new UserStateDto();
+        returnedDto.setUserId(123L);
+        returnedDto.setUsername(expectedUsername);
+
+        given(userPermissionsService.getUserState(expectedUsername))
+            .willReturn(returnedDto);
+
+        Map<String, Object> claims = Map.of(
+            "preferred_username", expectedUsername,
+            "name","Test User");
+        Jwt jwt = new Jwt("token", null, null, Map.of("alg", "none"), claims);
+        Authentication auth = new JwtAuthenticationToken(jwt);
+
+        // Act
+        ResponseEntity<UserStateDto> response = controller.getUserState(0L, auth);
+        UserStateDto result = response.getBody();
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(expectedUsername, result.getUsername());
+        verify(userPermissionsService).getUserState(expectedUsername);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/opal/controllers/advice/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/opal/controllers/advice/GlobalExceptionHandlerTest.java
@@ -1,0 +1,471 @@
+package uk.gov.hmcts.reform.opal.controllers.advice;
+
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.persistence.PersistenceException;
+import jakarta.persistence.QueryTimeoutException;
+import org.hibernate.LazyInitializationException;
+import org.hibernate.PropertyValueException;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.core.MethodParameter;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.dao.InvalidDataAccessResourceUsageException;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.orm.jpa.JpaSystemException;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.web.HttpMediaTypeNotAcceptableException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+import uk.gov.hmcts.reform.opal.authentication.exception.AuthenticationError;
+import uk.gov.hmcts.reform.opal.authentication.exception.MissingRequestHeaderException;
+import uk.gov.hmcts.reform.opal.exception.OpalApiException;
+import uk.gov.hmcts.reform.opal.exception.ResourceConflictException;
+
+import java.lang.reflect.Method;
+import java.net.ConnectException;
+import java.net.URI;
+import java.util.NoSuchElementException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@ContextConfiguration(classes = GlobalExceptionHandler.class)
+class GlobalExceptionHandlerTest {
+
+
+
+    @MockBean
+    MissingRequestHeaderException missingRequestHeaderException;
+
+
+    @Autowired
+    GlobalExceptionHandler globalExceptionHandler;
+
+    @Test
+    void testHandleHttpMediaTypeNotAcceptableException() {
+        HttpMediaTypeNotAcceptableException exception = new HttpMediaTypeNotAcceptableException("Not acceptable");
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler
+            .handleHttpMediaTypeNotAcceptableException(exception);
+
+        assertEquals(HttpStatus.NOT_ACCEPTABLE, response.getStatusCode());
+        ProblemDetail problemDetail = response.getBody();
+
+        assertEquals(HttpStatus.NOT_ACCEPTABLE.value(), problemDetail.getStatus());
+        assertEquals("Not Acceptable", problemDetail.getTitle());
+        assertEquals("The requested media type cannot be produced by the server", problemDetail.getDetail());
+        assertEquals(URI.create("https://hmcts.gov.uk/problems/not-acceptable"), problemDetail.getType());
+        assertNotNull(problemDetail.getInstance());
+
+        assertTrue(response.getHeaders().getContentType().toString()
+                       .contains(MediaType.APPLICATION_PROBLEM_JSON_VALUE));
+    }
+
+    @Test
+    void testHandleMethodArgumentTypeMismatchException() throws NoSuchMethodException {
+        // Simulate a value that caused the type mismatch
+        Object invalidValue = "invalidInt";
+        Class<?> requiredType = Integer.class;
+        String parameterName = "testParam";
+        Throwable cause = new NumberFormatException("For input string: \"invalidInt\"");
+        Method method = GlobalExceptionHandlerTest.class.getMethod("sampleMethod", Integer.class);
+        MethodParameter methodParameter = new MethodParameter(method, 0);
+
+        // Initialize MethodArgumentTypeMismatchException
+        MethodArgumentTypeMismatchException exception = new MethodArgumentTypeMismatchException(
+            invalidValue,
+            requiredType,
+            parameterName,
+            methodParameter,
+            cause
+        );
+
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler
+            .handleMethodArgumentTypeMismatchException(exception);
+
+        assertEquals(HttpStatus.NOT_ACCEPTABLE, response.getStatusCode());
+        ProblemDetail problemDetail = response.getBody();
+
+        assertEquals(HttpStatus.NOT_ACCEPTABLE.value(), problemDetail.getStatus());
+        assertEquals("Not Acceptable", problemDetail.getTitle());
+        assertEquals("Invalid parameter value format", problemDetail.getDetail());
+        assertEquals(URI.create("https://hmcts.gov.uk/problems/type-mismatch"), problemDetail.getType());
+        assertNotNull(problemDetail.getInstance());
+
+        assertTrue(response.getHeaders().getContentType().toString()
+                       .contains(MediaType.APPLICATION_PROBLEM_JSON_VALUE));
+    }
+
+    @Test
+    void testHandlePropertyValueException() {
+        PropertyValueException exception = new PropertyValueException("Property value exception", "entity",
+                                                                      "property");
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler.handlePropertyValueException(exception);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        ProblemDetail problemDetail = response.getBody();
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), problemDetail.getStatus());
+        assertEquals("Property Value Error", problemDetail.getTitle());
+        assertEquals("Invalid or missing value for a required property", problemDetail.getDetail());
+        assertEquals(URI.create("https://hmcts.gov.uk/problems/property-value-error"), problemDetail.getType());
+        assertEquals("entity", problemDetail.getProperties().get("entity"));
+        assertEquals("property", problemDetail.getProperties().get("property"));
+        assertNotNull(problemDetail.getInstance());
+
+        assertTrue(response.getHeaders().getContentType().toString()
+                       .contains(MediaType.APPLICATION_PROBLEM_JSON_VALUE));
+    }
+
+    @Test
+    void testHandleHttpMediaTypeNotSupportedException() {
+        HttpMediaTypeNotSupportedException exception =
+            new HttpMediaTypeNotSupportedException("Unsupported media type");
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler
+            .handleHttpMediaTypeNotSupportedException(exception);
+
+        assertEquals(HttpStatus.UNSUPPORTED_MEDIA_TYPE, response.getStatusCode());
+        ProblemDetail problemDetail = response.getBody();
+
+        assertEquals(HttpStatus.UNSUPPORTED_MEDIA_TYPE.value(), problemDetail.getStatus());
+        assertEquals("Unsupported Media Type", problemDetail.getTitle());
+        assertEquals("The Content-Type is not supported. Please use application/json", problemDetail.getDetail());
+        assertEquals(URI.create("https://hmcts.gov.uk/problems/unsupported-media-type"), problemDetail.getType());
+        assertNotNull(problemDetail.getInstance());
+
+        assertTrue(response.getHeaders().getContentType().toString()
+                       .contains(MediaType.APPLICATION_PROBLEM_JSON_VALUE));
+    }
+
+    @Test
+    void testHandleHttpMessageNotReadableException() {
+        HttpInputMessage msg = Mockito.mock(HttpInputMessage.class);
+        HttpMessageNotReadableException exception = new HttpMessageNotReadableException("Cannot read message", msg);
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler
+            .handleHttpMessageNotReadableException(exception);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        ProblemDetail problemDetail = response.getBody();
+
+        assertEquals(HttpStatus.BAD_REQUEST.value(), problemDetail.getStatus());
+        assertEquals("Bad Request", problemDetail.getTitle());
+        assertEquals("The request body could not be read. It may be missing or invalid JSON.",
+                     problemDetail.getDetail());
+        assertEquals(URI.create("https://hmcts.gov.uk/problems/message-not-readable"), problemDetail.getType());
+        assertNotNull(problemDetail.getInstance());
+
+        assertTrue(response.getHeaders().getContentType().toString()
+                       .contains(MediaType.APPLICATION_PROBLEM_JSON_VALUE));
+    }
+
+    @Test
+    void testHandleInvalidDataAccessApiUsageException() {
+        InvalidDataAccessApiUsageException exception =
+            new InvalidDataAccessApiUsageException("Invalid API usage", new Throwable("Root cause"));
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler
+            .handleInvalidDataAccessApiUsageException(exception);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        ProblemDetail problemDetail = response.getBody();
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), problemDetail.getStatus());
+        assertEquals("Internal Server Error", problemDetail.getTitle());
+        assertEquals("A problem occurred while accessing data", problemDetail.getDetail());
+        assertEquals(URI.create("https://hmcts.gov.uk/problems/invalid-data-access"), problemDetail.getType());
+        assertNotNull(problemDetail.getInstance());
+
+        assertTrue(response.getHeaders().getContentType().toString()
+                       .contains(MediaType.APPLICATION_PROBLEM_JSON_VALUE));
+    }
+
+    @Test
+    void handleInvalidDataAccessResourceUsageException_ShouldReturnInternalServerError() {
+        InvalidDataAccessResourceUsageException exception =
+            new InvalidDataAccessResourceUsageException("Invalid resource usage");
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler
+            .handleInvalidDataAccessResourceUsageException(exception);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        ProblemDetail problemDetail = response.getBody();
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), problemDetail.getStatus());
+        assertEquals("Internal Server Error", problemDetail.getTitle());
+        assertEquals("A problem occurred with the requested data resource", problemDetail.getDetail());
+        assertEquals(URI.create("https://hmcts.gov.uk/problems/invalid-resource-usage"), problemDetail.getType());
+        assertNotNull(problemDetail.getInstance());
+
+        assertTrue(response.getHeaders().getContentType().toString()
+                       .contains(MediaType.APPLICATION_PROBLEM_JSON_VALUE));
+    }
+
+    @Test
+    void testHandleEntityNotFoundException() {
+        EntityNotFoundException exception = new EntityNotFoundException("Entity not found");
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler.handleEntityNotFoundException(exception);
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        ProblemDetail problemDetail = response.getBody();
+
+        assertEquals(HttpStatus.NOT_FOUND.value(), problemDetail.getStatus());
+        assertEquals("Entity Not Found", problemDetail.getTitle());
+        assertEquals("The requested entity could not be found", problemDetail.getDetail());
+        assertEquals(URI.create("https://hmcts.gov.uk/problems/entity-not-found"), problemDetail.getType());
+        assertNotNull(problemDetail.getInstance());
+
+        assertTrue(response.getHeaders().getContentType().toString()
+                       .contains(MediaType.APPLICATION_PROBLEM_JSON_VALUE));
+    }
+
+    @Test
+    void testHandleNoSuchElementException() {
+        NoSuchElementException exception = new NoSuchElementException("No such element");
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler.handleNoSuchElementException(exception);
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        ProblemDetail problemDetail = response.getBody();
+
+        assertEquals(HttpStatus.NOT_FOUND.value(), problemDetail.getStatus());
+        assertEquals("No Value Present", problemDetail.getTitle());
+        assertEquals("The requested element does not exist", problemDetail.getDetail());
+        assertEquals(URI.create("https://hmcts.gov.uk/problems/no-such-element"), problemDetail.getType());
+        assertNotNull(problemDetail.getInstance());
+
+        assertTrue(response.getHeaders().getContentType().toString()
+                       .contains(MediaType.APPLICATION_PROBLEM_JSON_VALUE));
+    }
+
+    @Test
+    void handleOpalApiException_ReturnsInternalServerError() {
+        OpalApiException ex = new OpalApiException(
+            AuthenticationError.FAILED_TO_OBTAIN_AUTHENTICATION_CONFIG);
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler.handleOpalApiException(ex);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        ProblemDetail problemDetail = response.getBody();
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), problemDetail.getStatus());
+        assertEquals("Internal Server Error", problemDetail.getTitle());
+        assertEquals("An error occurred while processing your request", problemDetail.getDetail());
+        assertEquals(URI.create("https://hmcts.gov.uk/problems/opal-api-error"), problemDetail.getType());
+        assertNotNull(problemDetail.getInstance());
+
+        assertTrue(response.getHeaders().getContentType().toString()
+                       .contains(MediaType.APPLICATION_PROBLEM_JSON_VALUE));
+    }
+
+    @Test
+    void testHandleServletExceptions_queryTimeout() {
+        QueryTimeoutException exception = new QueryTimeoutException("Query timeout", null, null);
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler.handleServletExceptions(exception);
+
+        assertEquals(HttpStatus.REQUEST_TIMEOUT, response.getStatusCode());
+        ProblemDetail problemDetail = response.getBody();
+
+        assertEquals(HttpStatus.REQUEST_TIMEOUT.value(), problemDetail.getStatus());
+        assertEquals("Request Timeout", problemDetail.getTitle());
+        assertEquals("The request did not receive a response from the database within the timeout period",
+                     problemDetail.getDetail());
+        assertEquals(URI.create("https://hmcts.gov.uk/problems/query-timeout"), problemDetail.getType());
+        assertNotNull(problemDetail.getInstance());
+
+        assertTrue(response.getHeaders().getContentType().toString()
+                       .contains(MediaType.APPLICATION_PROBLEM_JSON_VALUE));
+    }
+
+    @Test
+    void handleServletExceptions_OtherDatabaseException_ShouldReturnInternalServerError() {
+        PersistenceException exception = new PersistenceException("Persistence exception");
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler.handleServletExceptions(exception);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        ProblemDetail problemDetail = response.getBody();
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), problemDetail.getStatus());
+        assertEquals("Internal Server Error", problemDetail.getTitle());
+        assertEquals("An unexpected error occurred while processing your request", problemDetail.getDetail());
+        assertEquals(URI.create("https://hmcts.gov.uk/problems/servlet-error"), problemDetail.getType());
+        assertNotNull(problemDetail.getInstance());
+
+        assertTrue(response.getHeaders().getContentType().toString()
+                       .contains(MediaType.APPLICATION_PROBLEM_JSON_VALUE));
+    }
+
+    @Test
+    void handleServletExceptions_ResourceNotFound_ShouldReturnNotFoundError() {
+        NoResourceFoundException exception = new NoResourceFoundException(HttpMethod.GET, "path");
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler.handleServletExceptions(exception);
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        ProblemDetail problemDetail = response.getBody();
+
+        assertEquals(HttpStatus.NOT_FOUND.value(), problemDetail.getStatus());
+        assertEquals("Not Found", problemDetail.getTitle());
+        assertEquals("The requested resource could not be found", problemDetail.getDetail());
+        assertEquals(URI.create("https://hmcts.gov.uk/problems/resource-not-found"), problemDetail.getType());
+        assertNotNull(problemDetail.getInstance());
+
+        assertTrue(response.getHeaders().getContentType().toString()
+                       .contains(MediaType.APPLICATION_PROBLEM_JSON_VALUE));
+    }
+
+    @Test
+    void testHandlePsqlException_serviceUnavailable() {
+        PSQLException exception = new PSQLException("PSQL Exception",
+                                                    PSQLState.CONNECTION_FAILURE,
+                                                    new ConnectException("Connection refused"));
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler.handlePsqlException(exception);
+
+        assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.getStatusCode());
+        ProblemDetail problemDetail = response.getBody();
+
+        assertEquals(HttpStatus.SERVICE_UNAVAILABLE.value(), problemDetail.getStatus());
+        assertEquals("Service Unavailable", problemDetail.getTitle());
+        assertEquals("Opal Fines Database is currently unavailable", problemDetail.getDetail());
+        assertEquals(URI.create("https://hmcts.gov.uk/problems/database-unavailable"), problemDetail.getType());
+        assertNotNull(problemDetail.getInstance());
+
+        assertTrue(response.getHeaders().getContentType().toString()
+                       .contains(MediaType.APPLICATION_PROBLEM_JSON_VALUE));
+    }
+
+    @Test
+    void handlePsqlException_WithOtherCause_ShouldReturnInternalServerError() {
+        PSQLException exception = new PSQLException("PSQL Exception", PSQLState.UNEXPECTED_ERROR,
+                                                    new Throwable("Unexpected error"));
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler.handlePsqlException(exception);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        ProblemDetail problemDetail = response.getBody();
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), problemDetail.getStatus());
+        assertEquals("Internal Server Error", problemDetail.getTitle());
+        assertEquals("A database error occurred while processing your request", problemDetail.getDetail());
+        assertEquals(URI.create("https://hmcts.gov.uk/problems/database-error"), problemDetail.getType());
+        assertNotNull(problemDetail.getInstance());
+
+        assertTrue(response.getHeaders().getContentType().toString()
+                       .contains(MediaType.APPLICATION_PROBLEM_JSON_VALUE));
+    }
+
+    @Test
+    void testHandleDataAccessResourceFailureException() {
+        DataAccessResourceFailureException exception =
+            new DataAccessResourceFailureException("Data access resource failure");
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler
+            .handleDataAccessResourceFailureException(exception);
+
+        assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.getStatusCode());
+        ProblemDetail problemDetail = response.getBody();
+
+        assertEquals(HttpStatus.SERVICE_UNAVAILABLE.value(), problemDetail.getStatus());
+        assertEquals("Service Unavailable", problemDetail.getTitle());
+        assertEquals("Opal Fines Database is currently unavailable", problemDetail.getDetail());
+        assertEquals(URI.create("https://hmcts.gov.uk/problems/database-unavailable"), problemDetail.getType());
+        assertNotNull(problemDetail.getInstance());
+
+        assertTrue(response.getHeaders().getContentType().toString()
+                       .contains(MediaType.APPLICATION_PROBLEM_JSON_VALUE));
+    }
+
+    @Test
+    void testHandleLazyInitializationException() {
+        LazyInitializationException exception =
+            new LazyInitializationException("Could not access Lazy Loaded Entity");
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler
+            .handleLazyInitializationException(exception);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        ProblemDetail problemDetail = response.getBody();
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), problemDetail.getStatus());
+        assertEquals("Internal Server Error", problemDetail.getTitle());
+        assertEquals("A data access error occurred.", problemDetail.getDetail());
+        assertEquals(URI.create("https://hmcts.gov.uk/problems/lazy-initialization"), problemDetail.getType());
+        assertNotNull(problemDetail.getInstance());
+
+        assertTrue(response.getHeaders().getContentType().toString()
+                       .contains(MediaType.APPLICATION_PROBLEM_JSON_VALUE));
+    }
+
+    @Test
+    void testHandleJpaSystemException() {
+        JpaSystemException jse = new JpaSystemException(new RuntimeException("Problem with JPA"));
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler
+            .handleJpaSystemException(jse);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        ProblemDetail problemDetail = response.getBody();
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), problemDetail.getStatus());
+        assertEquals("Internal Server Error", problemDetail.getTitle());
+        assertEquals("A persistence error occurred while processing your request", problemDetail.getDetail());
+        assertEquals(URI.create("https://hmcts.gov.uk/problems/jpa-system-error"), problemDetail.getType());
+        assertNotNull(problemDetail.getInstance());
+
+        assertTrue(response.getHeaders().getContentType().toString()
+                       .contains(MediaType.APPLICATION_PROBLEM_JSON_VALUE));
+    }
+
+
+
+    @Test
+    void testHandleIllegalArgumentException() {
+        IllegalArgumentException exception =
+            new IllegalArgumentException("Cannot include both A and B parameters");
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler
+            .handleIllegalArgumentException(exception);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        ProblemDetail problemDetail = response.getBody();
+
+        assertEquals(HttpStatus.BAD_REQUEST.value(), problemDetail.getStatus());
+        assertEquals("Bad Request", problemDetail.getTitle());
+        assertEquals("Invalid arguments were provided in the request", problemDetail.getDetail());
+        assertEquals(URI.create("https://hmcts.gov.uk/problems/illegal-argument"), problemDetail.getType());
+        assertNotNull(problemDetail.getInstance());
+
+        assertTrue(response.getHeaders().getContentType().toString()
+                       .contains(MediaType.APPLICATION_PROBLEM_JSON_VALUE));
+    }
+
+
+
+    @Test
+    void testHandleResourceConflictException() {
+        ResourceConflictException e = new ResourceConflictException("DraftAccount", "123", "BusinessUnits mismatch");
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler.handleResourceConflictException(e);
+
+        assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
+        ProblemDetail problemDetail = response.getBody();
+
+        assertEquals(HttpStatus.CONFLICT.value(), problemDetail.getStatus());
+        assertEquals("Conflict", problemDetail.getTitle());
+        assertEquals("A conflict occurred with the requested resource", problemDetail.getDetail());
+        assertEquals(URI.create("https://hmcts.gov.uk/problems/resource-conflict"), problemDetail.getType());
+        assertEquals("DraftAccount", problemDetail.getProperties().get("resourceType"));
+        assertEquals("123", problemDetail.getProperties().get("resourceId"));
+        assertEquals("BusinessUnits mismatch", problemDetail.getProperties().get("conflictReason"));
+        assertNotNull(problemDetail.getInstance());
+
+        assertTrue(response.getHeaders().getContentType().toString()
+                       .contains(MediaType.APPLICATION_PROBLEM_JSON_VALUE));
+    }
+
+    public static void sampleMethod(Integer testParam) {
+        // Sample method to simulate the method parameter
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/opal/service/UserPermissionsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/opal/service/UserPermissionsServiceTest.java
@@ -1,0 +1,104 @@
+package uk.gov.hmcts.reform.opal.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.opal.dto.UserStateDto;
+import uk.gov.hmcts.reform.opal.entity.UserEntity;
+import uk.gov.hmcts.reform.opal.mappers.UserStateMapper;
+import uk.gov.hmcts.reform.opal.repository.UserEntitlementRepository;
+import uk.gov.hmcts.reform.opal.repository.UserRepository;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserPermissionsServiceTest {
+
+    @Mock
+    private UserEntitlementRepository userEntitlementRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserStateMapper userStateMapper;
+
+    @Spy
+    @InjectMocks
+    private UserPermissionsService service;
+
+    private static final long USER_ID = 42L;
+    private static final String USERNAME = "opal-user";
+    private UserEntity userEntity;
+    private UserStateDto userDto;
+
+    @BeforeEach
+    void setUp() {
+        userEntity = new UserEntity();
+        userEntity.setUserId(USER_ID);
+        userEntity.setUsername(USERNAME);
+
+        userDto = new UserStateDto();
+        userDto.setUserId(USER_ID);
+        userDto.setUsername(USERNAME);
+    }
+
+    @Test
+    @DisplayName("getUserState(Long) throws when no entitlements and user missing")
+    void getUserState_longNoEntitlements_throws() {
+        when(userEntitlementRepository.findAllByUserIdWithFullJoins(USER_ID))
+            .thenReturn(Collections.emptySet());
+        when(userRepository.findById(USER_ID))
+            .thenReturn(java.util.Optional.empty());
+
+        EntityNotFoundException ex = assertThrows(
+            EntityNotFoundException.class,
+            () -> service.getUserState(USER_ID)
+        );
+        assertEquals("User not found with ID: " + USER_ID, ex.getMessage());
+
+        verify(userEntitlementRepository).findAllByUserIdWithFullJoins(USER_ID);
+        verify(userRepository).findById(USER_ID);
+    }
+
+    @Test
+    @DisplayName("getUserState(String) delegates to getUserState(Long) after lookup")
+    void getUserState_stringDelegatesToLong() {
+        when(userRepository.findOptionalByUsername(USERNAME))
+            .thenReturn(java.util.Optional.of(userEntity));
+        doReturn(userDto).when(service).getUserState(USER_ID);
+
+        UserStateDto result = service.getUserState(USERNAME);
+
+        assertEquals(userDto, result);
+        verify(userRepository).findOptionalByUsername(USERNAME);
+        verify(service).getUserState(USER_ID);
+    }
+
+    @Test
+    @DisplayName("getUserState(String) throws when username not found")
+    void getUserState_stringNotFound_throws() {
+        when(userRepository.findOptionalByUsername(USERNAME))
+            .thenReturn(java.util.Optional.empty());
+
+        EntityNotFoundException ex = assertThrows(
+            EntityNotFoundException.class,
+            () -> service.getUserState(USERNAME)
+        );
+        assertEquals("User not found with username: " + USERNAME, ex.getMessage());
+
+        verify(userRepository).findOptionalByUsername(USERNAME);
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

[PO-865](https://tools.hmcts.net/jira/browse/PO-865)

### Change description ###

Add get user state endpoint to user - for now the preferred_username claim is used to math a db.user (when user_id == 0). There will be a fair bit of refactoring needed for [Matching Key and JIT Provisioning](https://tools.hmcts.net/confluence/display/PO/TDIA%3A+User+Service+-+Matching+Key+and+JIT+Provisioning)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
