### PR TITLE
Revert "Update postgres Docker tag to v17.6"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 services:
   opal-user-db:
     container_name: opal-user-db
-    image: postgres:17.6
+    image: postgres:17.5
     restart: always
     environment:
       - POSTGRES_DB=opal-user-db


### PR DESCRIPTION
Reverts hmcts/opal-user-service#221

Do not update Postgres beyond v17.5 for now.