### PR TITLE
Force the flyway-code version number for all configurations.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   dependencies {
-    classpath("org.flywaydb:flyway-database-postgresql:11.13.0")
+    classpath("org.flywaydb:flyway-database-postgresql:11.13.2")
   }
 }
 
@@ -12,7 +12,7 @@ plugins {
   id 'com.github.ben-manes.versions' version '0.53.0'
   id 'org.sonarqube' version '6.3.1.5724'
   id 'uk.gov.hmcts.java' version '0.12.67'
-  id 'org.flywaydb.flyway' version '11.13.0'
+  id 'org.flywaydb.flyway' version '11.13.2'
   id 'net.serenity-bdd.serenity-gradle-plugin' version '4.2.34'
 }
 
@@ -55,6 +55,16 @@ configurations {
 
   smokeTestImplementation.extendsFrom testImplementation
   smokeTestRuntimeOnly.extendsFrom runtimeOnly
+}
+
+configurations.configureEach {
+  resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+    if (details.requested.group == 'org.flywaydb' &&
+      details.requested.name.contains('flyway-core')) {
+      details.useVersion '11.13.2'
+      details.because 'Fix for Flyway PluginRegister.getExact error'
+    }
+  }
 }
 
 tasks.withType(JavaCompile) {
@@ -284,7 +294,7 @@ dependencies {
 
   implementation group: 'io.rest-assured', name: 'rest-assured'
   implementation 'org.flywaydb:flyway-core'
-  runtimeOnly 'org.flywaydb:flyway-database-postgresql:11.13.0'
+  runtimeOnly 'org.flywaydb:flyway-database-postgresql:11.13.2'
   implementation 'org.postgresql:postgresql'
 
   implementation 'com.fasterxml.jackson.core:jackson-databind:2.16.2'


### PR DESCRIPTION
Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[*] No
```
