### PR TITLE
Lock Schema Validator to version 1.x.x

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,6 +14,13 @@
       "versioning": "fixed"
     },
     {
+      "description": "Lock the Schema Validator to v1.x.y to avoid major issues with v2+",
+      "matchManagers": ["gradle"],
+      "matchPackageNames": ["json-schema-validator"],
+      "matchPackagePrefixes": "com.networknt",
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
       "matchDatasources": ["docker"],
       "matchPackageNames": ["postgres"],
       "enabled": false

--- a/build.gradle
+++ b/build.gradle
@@ -321,7 +321,7 @@ dependencies {
   implementation group: 'org.apache.pdfbox', name: 'pdfbox', version: '3.0.6'
   implementation group: 'net.sf.saxon', name: 'Saxon-HE', version: '12.9'
 
-  implementation(group: 'com.networknt', name: 'json-schema-validator', version: '2.0.0');
+  implementation(group: 'com.networknt', name: 'json-schema-validator', version: '1.5.9');
   implementation(group: 'com.jayway.jsonpath', name: 'json-path', version: '2.10.0');
   testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
   testImplementation 'org.springframework.security:spring-security-test'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -11,5 +11,7 @@
   <!--End of false positives section -->
   <suppress>
     <cve>CVE-2024-1597</cve>
+    <!-- We do not use the mail api-->
+    <cve>CVE-2025-7962</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[*] Fixes broken build
[ ] No
```
