### PR TITLE
Added CVE Suppression for false positive

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -14,4 +14,15 @@
     <!-- We do not use the mail api-->
     <cve>CVE-2025-7962</cve>
   </suppress>
+
+  <suppress until="2026-04-01Z">
+    <notes><![CDATA[
+    This vulnerability relates to nu.validator:validator library which is not used within this project.
+Suppress CVE-2025-15104 only when Dependency-Check maps a dependency to the generic CPE
+"validator:validator" (known false-positive for various *-validator libraries).
+    ]]></notes>
+    <!-- Matches: cpe:2.3:a:validator:validator:<any>:*:*:*:*:*:*:* -->
+    <cpe>cpe:2.3:a:validator:validator:*:*:*:*:*:*:*:*</cpe>
+    <cve>CVE-2025-15104</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
Added suppression for as this was a false positive caused by generic CVE mapping.

This relates to dependency: https://mvnrepository.com/artifact/nu.validator/validator/26.1.11 which is not used within this application.

https://nvd.nist.gov/vuln/detail/CVE-2025-15104#range-20679426

Marked for review: 2026-04-01
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
