### PR TITLE
PO-2835 : Cache user state

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -346,7 +346,9 @@ dependencies {
   implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
   implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
   implementation 'org.springframework.boot:spring-boot-starter-cache'
+  implementation 'org.springframework.boot:spring-boot-starter-validation'
   implementation 'org.springframework.boot:spring-boot-flyway'
+  implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
   implementation 'org.springframework.boot:spring-boot-starter-integration'
   implementation 'org.springframework.integration:spring-integration-sftp'
@@ -396,6 +398,7 @@ dependencies {
   testImplementation 'com.auth0:java-jwt:4.5.1'
   testImplementation 'org.testcontainers:junit-jupiter:1.21.4'
   testImplementation 'org.testcontainers:testcontainers-postgresql'
+  testImplementation 'com.redis:testcontainers-redis'
   testImplementation(platform('org.junit:junit-bom:6.0.3'))
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
   testImplementation 'org.springframework.boot:spring-boot-starter-test', {

--- a/charts/opal-user-service/Chart.yaml
+++ b/charts/opal-user-service/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for opal-user-service App
 name: opal-user-service
 home: https://github.com/hmcts/opal-user-service
-version: 0.0.41
+version: 0.0.42
 maintainers:
   - name: HMCTS opal team
 dependencies:

--- a/charts/opal-user-service/Chart.yaml
+++ b/charts/opal-user-service/Chart.yaml
@@ -10,3 +10,7 @@ dependencies:
   - name: java
     version: 5.3.0
     repository: 'oci://hmctsprod.azurecr.io/helm'
+  - name: hmcts-redis
+    version: 0.8.0
+    repository: "oci://hmctsprod.azurecr.io/helm"
+    condition: hmcts-redis.enabled

--- a/charts/opal-user-service/values.dev.template.yaml
+++ b/charts/opal-user-service/values.dev.template.yaml
@@ -22,7 +22,7 @@ java:
         - name: OpalTestUserPassword
           alias: OPAL_TEST_USER_PASSWORD
   environment:
-    REDIS_CONNECTION_STRING: redis://${SERVICE_NAME}-redis-master:6379
+    REDIS_CONNECTION_STRING: redis://${SERVICE_NAME}-hmcts-redis-master:6379
     OPAL_USER_DB_HOST: "{{ .Release.Name }}-postgresql"
     OPAL_USER_DB_NAME: "{{ .Values.postgresql.auth.database}}"
     OPAL_USER_DB_USERNAME: "{{ .Values.postgresql.auth.username}}"

--- a/charts/opal-user-service/values.dev.template.yaml
+++ b/charts/opal-user-service/values.dev.template.yaml
@@ -22,7 +22,7 @@ java:
         - name: OpalTestUserPassword
           alias: OPAL_TEST_USER_PASSWORD
   environment:
-    REDIS_CONNECTION_STRING: redis://${SERVICE_NAME}-redis-master:6379
+    OPAL_REDIS_CONNECTION_STRING: redis://${SERVICE_NAME}-redis-master:6379
     OPAL_USER_DB_HOST: "{{ .Release.Name }}-postgresql"
     OPAL_USER_DB_NAME: "{{ .Values.postgresql.auth.database}}"
     OPAL_USER_DB_USERNAME: "{{ .Values.postgresql.auth.username}}"

--- a/charts/opal-user-service/values.dev.template.yaml
+++ b/charts/opal-user-service/values.dev.template.yaml
@@ -35,7 +35,7 @@ java:
     LAUNCH_DARKLY_ENABLED: false
   postgresql:
     enabled: true
-redis:
+hmcts-redis:
   enabled: true
   master:
     persistence:

--- a/charts/opal-user-service/values.dev.template.yaml
+++ b/charts/opal-user-service/values.dev.template.yaml
@@ -22,7 +22,7 @@ java:
         - name: OpalTestUserPassword
           alias: OPAL_TEST_USER_PASSWORD
   environment:
-    OPAL_REDIS_CONNECTION_STRING: redis://${SERVICE_NAME}-redis-master:6379
+    REDIS_CONNECTION_STRING: redis://${SERVICE_NAME}-redis-master:6379
     OPAL_USER_DB_HOST: "{{ .Release.Name }}-postgresql"
     OPAL_USER_DB_NAME: "{{ .Values.postgresql.auth.database}}"
     OPAL_USER_DB_USERNAME: "{{ .Values.postgresql.auth.username}}"

--- a/charts/opal-user-service/values.dev.template.yaml
+++ b/charts/opal-user-service/values.dev.template.yaml
@@ -22,6 +22,7 @@ java:
         - name: OpalTestUserPassword
           alias: OPAL_TEST_USER_PASSWORD
   environment:
+    REDIS_CONNECTION_STRING: redis://${SERVICE_NAME}-redis-master:6379
     OPAL_USER_DB_HOST: "{{ .Release.Name }}-postgresql"
     OPAL_USER_DB_NAME: "{{ .Values.postgresql.auth.database}}"
     OPAL_USER_DB_USERNAME: "{{ .Values.postgresql.auth.username}}"
@@ -34,3 +35,19 @@ java:
     LAUNCH_DARKLY_ENABLED: false
   postgresql:
     enabled: true
+redis:
+  enabled: true
+  master:
+    persistence:
+      enabled: false
+  auth:
+    enabled: false
+    sentinel: false
+  image:
+    registry: hmctsprod.azurecr.io
+    repository: imported/redis
+    tag: 8.2.1
+  sentinel:
+    enabled: false
+  metrics:
+    enabled: false

--- a/charts/opal-user-service/values.yaml
+++ b/charts/opal-user-service/values.yaml
@@ -26,8 +26,8 @@ java:
           alias: AAD_CLIENT_SECRET
         - name: OpalTestUserPassword
           alias: OPAL_TEST_USER_PASSWORD
-        - name: REDIS_CONNECTION_STRING
-          alias: OPAL_REDIS_CONNECTION_STRING
+        - name: redis-connection-string
+          alias: REDIS_CONNECTION_STRING
 
   environment:
     RUN_DB_MIGRATION_ON_STARTUP: true

--- a/charts/opal-user-service/values.yaml
+++ b/charts/opal-user-service/values.yaml
@@ -26,6 +26,8 @@ java:
           alias: AAD_CLIENT_SECRET
         - name: OpalTestUserPassword
           alias: OPAL_TEST_USER_PASSWORD
+        - name: REDIS_CONNECTION_STRING
+          alias: OPAL_REDIS_CONNECTION_STRING
 
   environment:
     RUN_DB_MIGRATION_ON_STARTUP: true

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -21,7 +21,7 @@ services:
       - OPAL_USER_DB_HOST=opal-db
       - OPAL_USER_DB_USERNAME=opal-db-user
       - OPAL_USER_DB_PASSWORD=opal-db-password
-      - OPAL_REDIS_CONNECTION_STRING=redis://redis:6379
+      - REDIS_CONNECTION_STRING=redis://redis:6379
     ports:
       - "${LOGGING_PORT:-4555}:4555"
     networks:

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -21,7 +21,7 @@ services:
       - OPAL_USER_DB_HOST=opal-db
       - OPAL_USER_DB_USERNAME=opal-db-user
       - OPAL_USER_DB_PASSWORD=opal-db-password
-      - REDIS_CONNECTION_STRING=redis://redis:6379
+      - OPAL_REDIS_CONNECTION_STRING=redis://redis:6379
     ports:
       - "${LOGGING_PORT:-4555}:4555"
     networks:

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -21,6 +21,7 @@ services:
       - OPAL_USER_DB_HOST=opal-db
       - OPAL_USER_DB_USERNAME=opal-db-user
       - OPAL_USER_DB_PASSWORD=opal-db-password
+      - REDIS_CONNECTION_STRING=redis://redis:6379
     ports:
       - "${LOGGING_PORT:-4555}:4555"
     networks:

--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/AbstractIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/AbstractIntegrationTest.java
@@ -36,7 +36,6 @@ public abstract class AbstractIntegrationTest {
         registry.add("spring.datasource.url", POSTGRES_CONTAINER::getJdbcUrl);
         registry.add("spring.datasource.username", POSTGRES_CONTAINER::getUsername);
         registry.add("spring.datasource.password", POSTGRES_CONTAINER::getPassword);
-        registry.add("spring.data.redis.host", REDIS_CONTAINER::getHost);
-        registry.add("spring.data.redis.port", REDIS_CONTAINER::getRedisPort);
+        registry.add("spring.data.redis.url", REDIS_CONTAINER::getRedisURI);
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/AbstractIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/AbstractIntegrationTest.java
@@ -12,6 +12,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import tools.jackson.databind.ObjectMapper;
 
 import static uk.gov.hmcts.reform.opal.TestContainerConfig.POSTGRES_CONTAINER;
+import static uk.gov.hmcts.reform.opal.TestContainerConfig.REDIS_CONTAINER;
 
 @SpringBootTest
 @ActiveProfiles("integration")
@@ -35,5 +36,7 @@ public abstract class AbstractIntegrationTest {
         registry.add("spring.datasource.url", POSTGRES_CONTAINER::getJdbcUrl);
         registry.add("spring.datasource.username", POSTGRES_CONTAINER::getUsername);
         registry.add("spring.datasource.password", POSTGRES_CONTAINER::getPassword);
+        registry.add("spring.data.redis.host", REDIS_CONTAINER::getHost);
+        registry.add("spring.data.redis.port", REDIS_CONTAINER::getRedisPort);
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/BaseIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/BaseIntegrationTest.java
@@ -19,6 +19,8 @@ public class BaseIntegrationTest {
         registry.add("spring.datasource.url", TestContainerConfig.POSTGRES_CONTAINER::getJdbcUrl);
         registry.add("spring.datasource.username", TestContainerConfig.POSTGRES_CONTAINER::getUsername);
         registry.add("spring.datasource.password", TestContainerConfig.POSTGRES_CONTAINER::getPassword);
+        registry.add("spring.data.redis.host", TestContainerConfig.REDIS_CONTAINER::getHost);
+        registry.add("spring.data.redis.port", TestContainerConfig.REDIS_CONTAINER::getRedisPort);
     }
 
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/BaseIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/BaseIntegrationTest.java
@@ -7,6 +7,8 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import static uk.gov.hmcts.reform.opal.TestContainerConfig.REDIS_CONTAINER;
+
 @Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles({"integration"})
@@ -19,8 +21,7 @@ public class BaseIntegrationTest {
         registry.add("spring.datasource.url", TestContainerConfig.POSTGRES_CONTAINER::getJdbcUrl);
         registry.add("spring.datasource.username", TestContainerConfig.POSTGRES_CONTAINER::getUsername);
         registry.add("spring.datasource.password", TestContainerConfig.POSTGRES_CONTAINER::getPassword);
-        registry.add("spring.data.redis.host", TestContainerConfig.REDIS_CONTAINER::getHost);
-        registry.add("spring.data.redis.port", TestContainerConfig.REDIS_CONTAINER::getRedisPort);
+        registry.add("spring.data.redis.url", REDIS_CONTAINER::getRedisURI);
     }
 
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/TestContainerConfig.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/TestContainerConfig.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.opal;
 
+import com.redis.testcontainers.RedisContainer;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.testcontainers.postgresql.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
@@ -8,6 +9,7 @@ import org.testcontainers.utility.DockerImageName;
 public class TestContainerConfig {
 
     public static final PostgreSQLContainer POSTGRES_CONTAINER;
+    public static final RedisContainer REDIS_CONTAINER;
 
     static {
         POSTGRES_CONTAINER = new PostgreSQLContainer(DockerImageName.parse("postgres:17.5"))
@@ -16,5 +18,9 @@ public class TestContainerConfig {
             .withPassword("test");
 
         POSTGRES_CONTAINER.start();
+
+        REDIS_CONTAINER = new RedisContainer(DockerImageName.parse("redis:6.2.6"))
+            .withExposedPorts(6379);
+        REDIS_CONTAINER.start();
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/UserPermissionsControllerGetIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/UserPermissionsControllerGetIntegrationTest.java
@@ -2,13 +2,16 @@ package uk.gov.hmcts.reform.opal.controllers;
 
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.verification.VerificationMode;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -28,6 +31,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -60,6 +64,9 @@ class UserPermissionsControllerGetIntegrationTest extends AbstractIntegrationTes
 
     @MockitoSpyBean
     private EventLoggingService eventLoggingService;
+
+    @Autowired
+    StringRedisTemplate redisTemplate;
 
     @ParameterizedTest
     @NullSource
@@ -389,8 +396,13 @@ class UserPermissionsControllerGetIntegrationTest extends AbstractIntegrationTes
     @DisplayName("V2 with ID Should return 200 and full V2 user state for a user with permissions")
     void getV2UserStateWithId_returnsFullState(boolean newLogin) throws Exception {
         long userIdWithPermissions = 500000000L;
-        Authentication auth = createJwtPrincipal("k9LpT2xVqR8m","opal-test@HMCTS.NET", "Pablo");
+        String subject = "k9LpT2xVqR8m";
+        Authentication auth = createJwtPrincipal(subject,"opal-test@HMCTS.NET", "Pablo");
         SecurityContextHolder.getContext().setAuthentication(auth);
+        // clear any existing user state in the cache
+        String cacheKey = "USER_STATE_" + subject;
+        redisTemplate.delete(cacheKey);
+
         MockHttpServletRequestBuilder builder = get("/v2" + URL_BASE + "/" + userIdWithPermissions + "/state");
         addLoginHeader(newLogin, builder);
         ResultActions actions = mockMvc.perform(builder);
@@ -416,7 +428,10 @@ class UserPermissionsControllerGetIntegrationTest extends AbstractIntegrationTes
         } else {
             verifyNoInteractions(eventLoggingService);
         }
-
+        // verification of redis caching of user state
+        assertThat(EXPECTED_V2_USER_STATE).isEqualTo(redisTemplate.opsForValue().get(cacheKey));
+        Long ttl = redisTemplate.getExpire(cacheKey, TimeUnit.MINUTES);
+        assertThat(ttl).isBetween(29L, 30L); //30 mins TTL seems to immediately tick down to 29 mins.
     }
 
     @ParameterizedTest
@@ -425,7 +440,8 @@ class UserPermissionsControllerGetIntegrationTest extends AbstractIntegrationTes
     void getV2UserStateWithId_updatesLastLoginDateInDb(boolean newLogin) throws Exception {
         long userIdWithPermissions = 500000000L;
 
-        Authentication auth = createJwtPrincipal("k9LpT2xVqR8m", "opal-test@HMCTS.NET", "Pablo");
+        String subject = "k9LpT2xVqR8m";
+        Authentication auth = createJwtPrincipal(subject, "opal-test@HMCTS.NET", "Pablo");
         SecurityContextHolder.getContext().setAuthentication(auth);
 
         LocalDateTime before = readLastLoginDate(userIdWithPermissions);
@@ -446,6 +462,72 @@ class UserPermissionsControllerGetIntegrationTest extends AbstractIntegrationTes
         } else {
             assertThat(after).isEqualTo(before);
         }
+    }
+
+    @Test
+    @DisplayName("PO-2835 AC2: should refresh cached user state and TTL")
+    void getV2UserStateViaPrincipal_refreshesTtlOfRedisEntry() throws Exception {
+        long userId = 500000000L;
+        String subject = "k9LpT2xVqR8m";
+        String cacheKey = "USER_STATE_" + subject;
+        Authentication auth = createJwtPrincipal(subject, "opal-test@HMCTS.NET", "Pablo");
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        //call once, check we have the initial TTL
+        ResultActions firstCall = mockMvc.perform(get("/v2" + URL_BASE + "/" + userId + "/state"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+        String firstBody = firstCall.andReturn().getResponse().getContentAsString();
+        assertThat(objectMapper.readTree(redisTemplate.opsForValue().get(cacheKey)))
+            .isEqualTo(objectMapper.readTree(firstBody));
+        Long ttlBeforeRefreshMinutes1 = redisTemplate.getExpire(cacheKey, TimeUnit.MINUTES);
+        assertThat(ttlBeforeRefreshMinutes1).isBetween(29L, 30L);
+
+        // expire the cache entry so that only 5 minutes left
+        redisTemplate.expire(cacheKey, 5, TimeUnit.MINUTES);
+        Long ttlBeforeRefreshMinutes2 = redisTemplate.getExpire(cacheKey, TimeUnit.MINUTES);
+        assertThat(ttlBeforeRefreshMinutes2).isBetween(4L, 5L);
+
+        //call a second time and check we get the new TTL.
+        ResultActions secondCall = mockMvc.perform(get("/v2" + URL_BASE + "/" + userId + "/state"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+        String secondBody = secondCall.andReturn().getResponse().getContentAsString();
+        assertThat(objectMapper.readTree(redisTemplate.opsForValue().get(cacheKey)))
+            .isEqualTo(objectMapper.readTree(secondBody));
+        Long ttlBeforeRefreshMinutes3 = redisTemplate.getExpire(cacheKey, TimeUnit.MINUTES);
+        assertThat(ttlBeforeRefreshMinutes3).isBetween(29L, 30L);
+    }
+
+    @Test
+    @DisplayName("PO-2835 AC3: cached user state should expire and return no data")
+    void getV2UserStateWithId_cachedStateExpiresAfterTtl() throws Exception {
+        long userId = 500000000L;
+        String subject = "k9LpT2xVqR8m";
+        String cacheKey = "USER_STATE_" + subject;
+        Authentication auth = createJwtPrincipal(subject, "opal-test@HMCTS.NET", "Pablo");
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        // Populate cache by calling the API with valid data.
+        mockMvc.perform(get("/v2" + URL_BASE + "/" + userId + "/state"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+
+        assertThat(redisTemplate.opsForValue().get(cacheKey)).isEqualTo(EXPECTED_V2_USER_STATE);
+
+        // Simulate "30 minutes later"
+        Boolean ttlSet = redisTemplate.expire(cacheKey, 1, TimeUnit.SECONDS);
+        assertThat(ttlSet).isTrue();
+
+        // Poll until the entry disappears from Redis
+        String cachedValue = redisTemplate.opsForValue().get(cacheKey);
+        long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (cachedValue != null && System.nanoTime() < deadlineNanos) {
+            Thread.sleep(100L);
+            cachedValue = redisTemplate.opsForValue().get(cacheKey);
+        }
+
+        assertThat(cachedValue).isNull();
     }
 
     private LocalDateTime readLastLoginDate(long userId) {
@@ -470,77 +552,62 @@ class UserPermissionsControllerGetIntegrationTest extends AbstractIntegrationTes
 
     public static final String EXPECTED_V2_USER_STATE =
         """
-            {
-              "user_id": 500000000,
-              "username": "opal-test@HMCTS.NET",
-              "name": "Pablo",
-              "status": "ACTIVE",
-              "version": 0,
-              "cache_name": null,
-              "domains": {
-                "fines": {
-                  "business_unit_users": [
-                    {
-                      "business_unit_user_id": "L065JG",
-                      "business_unit_id": 70,
-                      "permissions": [
-                        {
-                          "permission_id": 1,
-                          "permission_name": "Create and Manage Draft Accounts"
-                        },
-                        {
-                          "permission_id": 3,
-                          "permission_name": "Account Enquiry"
-                        },
-                        {
-                          "permission_id": 4,
-                          "permission_name": "Collection Order"
-                        },
-                        {
-                          "permission_id": 5,
-                          "permission_name": "Check and Validate Draft Accounts"
-                        },
-                        {
-                          "permission_id": 6,
-                          "permission_name": "Search and View Accounts"
-                        }
-                      ]
-                    },
-                    {
-                      "business_unit_user_id": "L066JG",
-                      "business_unit_id": 68,
-                      "permissions": []
-                    },
-                    {
-                      "business_unit_user_id": "L067JG",
-                      "business_unit_id": 73,
-                      "permissions": []
-                    },
-                    {
-                      "business_unit_user_id": "L073JG",
-                      "business_unit_id": 71,
-                      "permissions": []
-                    },
-                    {
-                      "business_unit_user_id": "L077JG",
-                      "business_unit_id": 67,
-                      "permissions": []
-                    },
-                    {
-                      "business_unit_user_id": "L078JG",
-                      "business_unit_id": 69,
-                      "permissions": []
-                    },
-                    {
-                      "business_unit_user_id": "L080JG",
-                      "business_unit_id": 61,
-                      "permissions": []
-                    }
-                  ]
-                }
-              }
+        {
+          "user_id" : 500000000,
+          "username" : "opal-test@HMCTS.NET",
+          "name" : "Pablo",
+          "status" : "ACTIVE",
+          "version" : 0,
+          "cache_name" : "USER_STATE_k9LpT2xVqR8m",
+          "domains" : {
+            "fines" : {
+              "business_unit_users" : [ {
+                "business_unit_user_id" : "L065JG",
+                "business_unit_id" : 70,
+                "permissions" : [ {
+                  "permission_id" : 1,
+                  "permission_name" : "Create and Manage Draft Accounts"
+                }, {
+                  "permission_id" : 3,
+                  "permission_name" : "Account Enquiry"
+                }, {
+                  "permission_id" : 4,
+                  "permission_name" : "Collection Order"
+                }, {
+                  "permission_id" : 5,
+                  "permission_name" : "Check and Validate Draft Accounts"
+                }, {
+                  "permission_id" : 6,
+                  "permission_name" : "Search and View Accounts"
+                } ]
+              }, {
+                "business_unit_user_id" : "L066JG",
+                "business_unit_id" : 68,
+                "permissions" : [ ]
+              }, {
+                "business_unit_user_id" : "L067JG",
+                "business_unit_id" : 73,
+                "permissions" : [ ]
+              }, {
+                "business_unit_user_id" : "L073JG",
+                "business_unit_id" : 71,
+                "permissions" : [ ]
+              }, {
+                "business_unit_user_id" : "L077JG",
+                "business_unit_id" : 67,
+                "permissions" : [ ]
+              }, {
+                "business_unit_user_id" : "L078JG",
+                "business_unit_id" : 69,
+                "permissions" : [ ]
+              }, {
+                "business_unit_user_id" : "L080JG",
+                "business_unit_id" : 61,
+                "permissions" : [ ]
+              } ]
             }
-        """;
+          }
+        }""";
 
     private JwtAuthenticationToken createJwtPrincipal() {
         return createJwtPrincipal("jjqwGAERGW43","test-user@HMCTS.NET", "Pablo");

--- a/src/main/java/uk/gov/hmcts/reform/opal/config/properties/CacheConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/config/properties/CacheConfiguration.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.reform.opal.config.properties;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.validation.annotation.Validated;
+
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "cache")
+@Validated
+public class CacheConfiguration {
+    @NotNull
+    private Long userStateTimeoutMinutes;
+}

--- a/src/main/java/uk/gov/hmcts/reform/opal/service/UserPermissionsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/service/UserPermissionsService.java
@@ -19,6 +19,7 @@ import com.nimbusds.jwt.JWTClaimsSet;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
@@ -169,7 +170,11 @@ public class UserPermissionsService implements UserPermissionsProxy {
         dto.setCacheName(cacheKey);
         String dtoJson = objectToPrettyJson(dto);
         Long cacheTimeout = cacheConfiguration.getUserStateTimeoutMinutes();
-        redisTemplate.opsForValue().set(cacheKey, dtoJson, cacheTimeout, TimeUnit.MINUTES);
+        try {
+            redisTemplate.opsForValue().set(cacheKey, dtoJson, cacheTimeout, TimeUnit.MINUTES);
+        } catch (DataAccessException e) {
+            log.warn("Unable to cache user state for user {}, reason: {}", user.getUsername(), e.getMessage());
+        }
     }
 
     private void logUserAuthenticationEvent(Long userId) {

--- a/src/main/java/uk/gov/hmcts/reform/opal/service/UserPermissionsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/service/UserPermissionsService.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.opal.service;
 
+import static uk.gov.hmcts.opal.common.dto.ToJsonString.objectToPrettyJson;
 import static uk.gov.hmcts.opal.common.logging.LogUtil.getRequestTimestamp;
 import static uk.gov.hmcts.reform.opal.util.VersionUtils.verifyIfMatch;
 
@@ -10,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -17,6 +19,7 @@ import com.nimbusds.jwt.JWTClaimsSet;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.Authentication;
@@ -32,6 +35,7 @@ import uk.gov.hmcts.opal.common.user.authentication.service.AccessTokenService;
 import uk.gov.hmcts.opal.common.user.authorisation.client.dto.BusinessUnitUserDto;
 import uk.gov.hmcts.opal.common.user.authorisation.client.dto.UserStateDto;
 import uk.gov.hmcts.opal.common.user.authorisation.client.dto.UserStateV2Dto;
+import uk.gov.hmcts.reform.opal.config.properties.CacheConfiguration;
 import uk.gov.hmcts.reform.opal.dto.UserDto;
 import uk.gov.hmcts.reform.opal.entity.BusinessUnitUserEntity;
 import uk.gov.hmcts.reform.opal.entity.UserEntitlementEntity;
@@ -62,8 +66,9 @@ public class UserPermissionsService implements UserPermissionsProxy {
     private final UserMapper userMapper;
     private final AccessTokenService tokenService;
     private final SecurityEventLoggingService securityEventLoggingService;
+    private final StringRedisTemplate redisTemplate;
     private final Clock clock;
-
+    private final CacheConfiguration cacheConfiguration;
 
     @Transactional(readOnly = true)
     @Deprecated //Use getUserStateV2 equivalent method
@@ -128,6 +133,7 @@ public class UserPermissionsService implements UserPermissionsProxy {
             logUserAuthenticationEvent(user.getUserId());
             updateLastLogin(user);
         }
+        cacheUserState(dto, user);
         return dto;
     }
 
@@ -145,6 +151,7 @@ public class UserPermissionsService implements UserPermissionsProxy {
                 logUserAuthenticationEvent(clientUserId);
                 updateLastLogin(user);
             }
+            cacheUserState(dto, user);
             return dto;
         }
     }
@@ -155,6 +162,14 @@ public class UserPermissionsService implements UserPermissionsProxy {
         String subject = extractSubject(jwt);
         UserEntity user = proxy.getUser(subject);
         return user.getUserId();
+    }
+
+    private void cacheUserState(UserStateV2Dto dto, UserEntity user) {
+        String cacheKey = "USER_STATE_" + user.getTokenSubject();
+        dto.setCacheName(cacheKey);
+        String dtoJson = objectToPrettyJson(dto);
+        Long cacheTimeout = cacheConfiguration.getUserStateTimeoutMinutes();
+        redisTemplate.opsForValue().set(cacheKey, dtoJson, cacheTimeout, TimeUnit.MINUTES);
     }
 
     private void logUserAuthenticationEvent(Long userId) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -21,6 +21,9 @@ springdoc:
   writer-with-order-by-keys: true
 
 spring:
+  data:
+    redis:
+      url: ${REDIS_CONNECTION_STRING:redis://localhost:6379}
   config:
     import: "optional:configtree:/mnt/secrets/opal/"
   application:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,7 +14,7 @@ management:
     web:
       base-path: /
       exposure:
-        include: health, info, prometheus, env
+        include: health, info, prometheus
 
 springdoc:
   packagesToScan: uk.gov.hmcts.reform.auth-service.controllers,uk.gov.hmcts.reform.opal.controllers,uk.gov.hmcts.reform.opal.authentication.controller

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -132,3 +132,6 @@ logging:
 user:
   service:
     url: ${OPAL_USER_SERVICE_API_URL:http://localhost:4555}
+
+cache:
+  user-state-timeout-minutes: 30

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -23,7 +23,7 @@ springdoc:
 spring:
   data:
     redis:
-      url: ${OPAL_REDIS_CONNECTION_STRING:redis://localhost:6379}
+      url: ${REDIS_CONNECTION_STRING:redis://localhost:6379}
   config:
     import: "optional:configtree:/mnt/secrets/opal/"
   application:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,7 +14,7 @@ management:
     web:
       base-path: /
       exposure:
-        include: health, info, prometheus
+        include: health, info, prometheus, env
 
 springdoc:
   packagesToScan: uk.gov.hmcts.reform.auth-service.controllers,uk.gov.hmcts.reform.opal.controllers,uk.gov.hmcts.reform.opal.authentication.controller

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -23,7 +23,7 @@ springdoc:
 spring:
   data:
     redis:
-      url: ${REDIS_CONNECTION_STRING:redis://localhost:6379}
+      url: ${OPAL_REDIS_CONNECTION_STRING:redis://localhost:6379}
   config:
     import: "optional:configtree:/mnt/secrets/opal/"
   application:

--- a/src/test/java/uk/gov/hmcts/reform/opal/dev/ContainerConfiguration.java
+++ b/src/test/java/uk/gov/hmcts/reform/opal/dev/ContainerConfiguration.java
@@ -4,11 +4,13 @@ import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.HostConfig;
 import com.github.dockerjava.api.model.PortBinding;
 import com.github.dockerjava.api.model.Ports;
+import com.redis.testcontainers.RedisContainer;
 import org.springframework.boot.devtools.restart.RestartScope;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
 import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
 
 @TestConfiguration(proxyBeanMethods = false)
 public class ContainerConfiguration {
@@ -19,7 +21,7 @@ public class ContainerConfiguration {
     PostgreSQLContainer databaseContainer() {
         return new PostgreSQLContainer("postgres:17.5")
             .withCreateContainerCmdModifier(cmd -> {
-                cmd.withName("test-container-opal-user-db");
+                cmd.withName("testcontainers-postgres");
                 cmd.withHostConfig(
                     new HostConfig().withPortBindings(
                         new PortBinding(Ports.Binding.bindPort(5433), new ExposedPort(5432))
@@ -28,8 +30,27 @@ public class ContainerConfiguration {
             })
             .withExposedPorts(5432)
             .withDatabaseName("opal-user-db")
-            .withUsername("opal-user")
-            .withPassword("opal-user")
+            .withUsername("opal-db-user")
+            .withPassword("opal-db-password")
             .withReuse(true);
     }
+
+    @Bean
+    @ServiceConnection
+    @RestartScope
+    RedisContainer redisContainer() {
+        RedisContainer redisContainer = new RedisContainer(DockerImageName.parse("redis:6.2.6"))
+            .withExposedPorts(6379)
+            .withCreateContainerCmdModifier(cmd -> {
+                cmd.withName("testcontainers-redis");
+                cmd.withHostConfig(
+                    new HostConfig().withPortBindings(
+                        new PortBinding(Ports.Binding.bindPort(6379), new ExposedPort(6379))
+                    )
+                );
+            });
+        redisContainer.start();
+        return redisContainer;
+    }
+
 }

--- a/src/test/java/uk/gov/hmcts/reform/opal/service/UserPermissionsServiceV2Test.java
+++ b/src/test/java/uk/gov/hmcts/reform/opal/service/UserPermissionsServiceV2Test.java
@@ -51,6 +51,12 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class UserPermissionsServiceV2Test {
 
+    private static final long USER_ID = 42L;
+    private static final long CACHE_TIMEOUT_MINUTES = 30L;
+    private static final String TOKEN_PREFERRED_USERNAME = "opal-user@hmcts.net";
+    private static final String TOKEN_NAME = "John Smith";
+    private static final String TOKEN_SUBJECT = "hcv732JFVWhf3Fd";
+
     @Mock
     SecurityContext securityContext;
 
@@ -95,12 +101,6 @@ class UserPermissionsServiceV2Test {
 
     @InjectMocks
     private UserPermissionsService service;
-
-    private static final long USER_ID = 42L;
-    private static final long CACHE_TIMEOUT_MINUTES = 30L;
-    private static final String TOKEN_PREFERRED_USERNAME = "opal-user@hmcts.net";
-    private static final String TOKEN_NAME = "John Smith";
-    private static final String TOKEN_SUBJECT = "hcv732JFVWhf3Fd";
 
     private UserEntity userEntity;
     private UserStateV2Dto dto;

--- a/src/test/java/uk/gov/hmcts/reform/opal/service/UserPermissionsServiceV2Test.java
+++ b/src/test/java/uk/gov/hmcts/reform/opal/service/UserPermissionsServiceV2Test.java
@@ -4,9 +4,12 @@ import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.jaas.JaasAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -19,6 +22,7 @@ import uk.gov.hmcts.opal.common.logging.SecurityEventLoggingService;
 import uk.gov.hmcts.opal.common.user.authentication.service.AccessTokenService;
 import uk.gov.hmcts.opal.common.user.authentication.service.TokenValidator;
 import uk.gov.hmcts.opal.common.user.authorisation.client.dto.UserStateV2Dto;
+import uk.gov.hmcts.reform.opal.config.properties.CacheConfiguration;
 import uk.gov.hmcts.reform.opal.entity.UserEntity;
 import uk.gov.hmcts.reform.opal.mappers.UserMapper;
 import uk.gov.hmcts.reform.opal.mappers.UserStateMapper;
@@ -31,10 +35,14 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
+import static uk.gov.hmcts.opal.common.dto.ToJsonString.objectToPrettyJson;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -79,16 +87,26 @@ class UserPermissionsServiceV2Test {
     @Mock
     private Clock clock;
 
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
     @InjectMocks
     private UserPermissionsService service;
 
     private static final long USER_ID = 42L;
+    private static final long CACHE_TIMEOUT_MINUTES = 30L;
     private static final String TOKEN_PREFERRED_USERNAME = "opal-user@hmcts.net";
     private static final String TOKEN_NAME = "John Smith";
     private static final String TOKEN_SUBJECT = "hcv732JFVWhf3Fd";
 
     private UserEntity userEntity;
     private UserStateV2Dto dto;
+
+    @Mock
+    private CacheConfiguration cacheConfiguration;
 
     @BeforeEach
     void setUp() {
@@ -101,6 +119,8 @@ class UserPermissionsServiceV2Test {
             .build();
         dto = UserStateV2Dto.builder().build();
         SecurityContextHolder.clearContext();
+        lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        lenient().when(cacheConfiguration.getUserStateTimeoutMinutes()).thenReturn(CACHE_TIMEOUT_MINUTES);
     }
 
     @Test
@@ -182,6 +202,7 @@ class UserPermissionsServiceV2Test {
         assertThat(userEntity.getLastLoginDate())
             .isEqualTo(LocalDateTime.ofInstant(fixedInstant, fixedZone));
         verify(userRepository).saveAndFlush(userEntity);
+        assertDtoWasCachedForSubject(TOKEN_SUBJECT);
     }
 
     @Test
@@ -205,6 +226,7 @@ class UserPermissionsServiceV2Test {
         // Assert
         assertThat(result).isEqualTo(dto);
         verifyNoInteractions(securityEventLoggingService);
+        assertDtoWasCachedForSubject(TOKEN_SUBJECT);
     }
 
     @Test
@@ -291,6 +313,7 @@ class UserPermissionsServiceV2Test {
         assertThat(userEntity.getLastLoginDate())
             .isEqualTo(LocalDateTime.ofInstant(fixedInstant, fixedZone));
         verify(userRepository).saveAndFlush(userEntity);
+        assertDtoWasCachedForSubject(TOKEN_SUBJECT);
     }
 
     @Test
@@ -306,6 +329,7 @@ class UserPermissionsServiceV2Test {
         // Assert
         assertThat(result).isEqualTo(dto);
         verifyNoInteractions(securityEventLoggingService);
+        assertDtoWasCachedForSubject(TOKEN_SUBJECT);
     }
 
     @Test
@@ -349,6 +373,7 @@ class UserPermissionsServiceV2Test {
         assertThat(userEntity.getLastLoginDate())
             .isEqualTo(LocalDateTime.ofInstant(fixedInstant, fixedZone));
         verify(userRepository).saveAndFlush(userEntity);
+        assertDtoWasCachedForSubject(TOKEN_SUBJECT);
     }
 
     @Test
@@ -377,5 +402,20 @@ class UserPermissionsServiceV2Test {
         assertThat(userEntity.getLastLoginDate())
             .isEqualTo(LocalDateTime.ofInstant(fixedInstant, fixedZone));
         verify(userRepository).saveAndFlush(userEntity);
+        assertDtoWasCachedForSubject(TOKEN_SUBJECT);
+    }
+
+    private void assertDtoWasCachedForSubject(String subject) {
+        String cacheKey = "USER_STATE_" + subject;
+        ArgumentCaptor<String> payloadCaptor = ArgumentCaptor.forClass(String.class);
+
+        verify(valueOperations).set(
+            eq(cacheKey),
+            payloadCaptor.capture(),
+            eq(CACHE_TIMEOUT_MINUTES),
+            eq(TimeUnit.MINUTES)
+        );
+        assertThat(dto.getCacheName()).isEqualTo(cacheKey);
+        assertThat(payloadCaptor.getValue()).isEqualTo(objectToPrettyJson(dto));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/opal/service/UserPermissionsServiceV2Test.java
+++ b/src/test/java/uk/gov/hmcts/reform/opal/service/UserPermissionsServiceV2Test.java
@@ -8,6 +8,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.http.HttpStatus;
@@ -39,9 +40,12 @@ import java.util.concurrent.TimeUnit;
 
 import static uk.gov.hmcts.opal.common.dto.ToJsonString.objectToPrettyJson;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -227,6 +231,52 @@ class UserPermissionsServiceV2Test {
         assertThat(result).isEqualTo(dto);
         verifyNoInteractions(securityEventLoggingService);
         assertDtoWasCachedForSubject(TOKEN_SUBJECT);
+    }
+
+    @Test
+    void getUserStateV2_whenRedisCachingFails_doesNotThrowAndReturnsDto() {
+
+        // arrange
+        JwtAuthenticationToken authentication = mock(JwtAuthenticationToken.class);
+        when(authentication.getToken()).thenReturn(jwt);
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        SecurityContextHolder.setContext(securityContext);
+
+        when(jwt.getSubject()).thenReturn(TOKEN_SUBJECT);
+        when(proxy.getUserV2(TOKEN_SUBJECT)).thenReturn(userEntity);
+        when(jwt.getClaimAsString("preferred_username")).thenReturn(TOKEN_PREFERRED_USERNAME);
+        when(jwt.getClaimAsString("name")).thenReturn(TOKEN_NAME);
+        when(userStateMapper.toUserStateV2Dto(userEntity)).thenReturn(dto);
+
+        doThrow(new DataAccessResourceFailureException("Redis unavailable"))
+            .when(valueOperations)
+            .set(eq("USER_STATE_" + TOKEN_SUBJECT), anyString(), eq(CACHE_TIMEOUT_MINUTES), eq(TimeUnit.MINUTES));
+
+        // act & assert
+        UserStateV2Dto result = assertDoesNotThrow(() -> service.getUserStateV2(proxy, false));
+
+        assertThat(result).isEqualTo(dto);
+        assertThat(result.getCacheName()).isEqualTo("USER_STATE_" + TOKEN_SUBJECT);
+        verifyNoInteractions(securityEventLoggingService);
+    }
+
+    @Test
+    void getUserStateV2IdMethod_whenRedisCachingFails_doesNotThrowAndReturnsDto() {
+
+        // arrange
+        when(proxy.getUserV2(USER_ID)).thenReturn(userEntity);
+        when(userStateMapper.toUserStateV2Dto(userEntity)).thenReturn(dto);
+
+        doThrow(new DataAccessResourceFailureException("Redis unavailable"))
+            .when(valueOperations)
+            .set(eq("USER_STATE_" + TOKEN_SUBJECT), anyString(), eq(CACHE_TIMEOUT_MINUTES), eq(TimeUnit.MINUTES));
+
+        // act & assert
+        UserStateV2Dto result = assertDoesNotThrow(() -> service.getUserStateV2(USER_ID, proxy, false));
+
+        assertThat(result).isEqualTo(dto);
+        assertThat(result.getCacheName()).isEqualTo("USER_STATE_" + TOKEN_SUBJECT);
+        verifyNoInteractions(securityEventLoggingService);
     }
 
     @Test


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/PO-2835
"BE - Update user state to store the user state in shared Redis Cache"

Changes:

- When the V2 user state is requested in the API, it is now cached in Redis.
- TTL is of this cached state is a configurable property

**Does this PR introduce a breaking change?** (check one with "x")

```
[  ] Yes
[X ] No
```
