### PR TITLE
PO-2833 : fixing permission bug

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/UserPermissionsControllerGetIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/UserPermissionsControllerGetIntegrationTest.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.reform.opal.controllers;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -67,6 +69,8 @@ class UserPermissionsControllerGetIntegrationTest extends AbstractIntegrationTes
 
     @Autowired
     StringRedisTemplate redisTemplate;
+
+    private ObjectMapper objectMapper = new ObjectMapper();
 
     @ParameterizedTest
     @NullSource
@@ -412,7 +416,10 @@ class UserPermissionsControllerGetIntegrationTest extends AbstractIntegrationTes
         actions.andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON));
 
-        assertThat(body).isEqualTo(objectMapper.readTree(EXPECTED_V2_USER_STATE).toString());
+        JsonNode expectedNode = objectMapper.readTree(EXPECTED_V2_USER_STATE);
+        JsonNode actualNode = objectMapper.readTree(body);
+        assertThat(actualNode).isEqualTo(expectedNode);
+
         if (newLogin) {
             verify(eventLoggingService).logEvent(
                 eq("User Authentication"),
@@ -429,7 +436,10 @@ class UserPermissionsControllerGetIntegrationTest extends AbstractIntegrationTes
             verifyNoInteractions(eventLoggingService);
         }
         // verification of redis caching of user state
-        assertThat(EXPECTED_V2_USER_STATE).isEqualTo(redisTemplate.opsForValue().get(cacheKey));
+        JsonNode actualFromCacheNode = objectMapper.readTree(redisTemplate.opsForValue().get(cacheKey));
+        assertThat(actualFromCacheNode).isEqualTo(expectedNode);
+
+
         Long ttl = redisTemplate.getExpire(cacheKey, TimeUnit.MINUTES);
         assertThat(ttl).isBetween(29L, 30L); //30 mins TTL seems to immediately tick down to 29 mins.
     }
@@ -513,7 +523,9 @@ class UserPermissionsControllerGetIntegrationTest extends AbstractIntegrationTes
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON));
 
-        assertThat(redisTemplate.opsForValue().get(cacheKey)).isEqualTo(EXPECTED_V2_USER_STATE);
+        JsonNode expectedNode = objectMapper.readTree(EXPECTED_V2_USER_STATE);
+        JsonNode actualNode = objectMapper.readTree(redisTemplate.opsForValue().get(cacheKey));
+        assertThat(actualNode).isEqualTo(expectedNode);
 
         // Simulate "30 minutes later"
         Boolean ttlSet = redisTemplate.expire(cacheKey, 1, TimeUnit.SECONDS);

--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/repository/RoleRepositoryIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/repository/RoleRepositoryIntegrationTest.java
@@ -34,13 +34,13 @@ class RoleRepositoryIntegrationTest extends BaseIntegrationTest {
 
         assertThat(finesRole1.getVersionNumber()).isEqualTo(2);
         assertThat(finesRole1.getApplicationFunctionList()).containsExactly(
-            "CREATE_MANAGE_DRAFT_ACCOUNTS", "ACCOUNT_ENQUIRY");
+            "Create and Manage Draft Accounts", "Account Enquiry");
         assertThat(finesRole2.getVersionNumber()).isEqualTo(3);
         assertThat(finesRole2.getApplicationFunctionList()).containsExactly(
-            "COLLECTION_ORDER", "CHECK_VALIDATE_DRAFT_ACCOUNTS", "SEARCH_AND_VIEW_ACCOUNTS");
+            "Collection Order", "Check and Validate Draft Accounts", "Search and View Accounts");
         assertThat(confiscationRole3.getVersionNumber()).isEqualTo(2);
         assertThat(confiscationRole3.getApplicationFunctionList()).containsExactly(
-            "CREATE_MANAGE_DRAFT_ACCOUNTS", "COLLECTION_ORDER");
+            "Create and Manage Draft Accounts", "Collection Order");
     }
 
     @Test

--- a/src/integrationTest/resources/db.insertData/insert_authorisation_data.sql
+++ b/src/integrationTest/resources/db.insertData/insert_authorisation_data.sql
@@ -58,13 +58,13 @@ VALUES (112687, 'L065JG', 41), -- BU 70 gets 'Account Enquiry - Account Notes'
        (500001, 'L080JG', 500); -- BU 61 gets 'Collection Order'
 
 INSERT INTO roles (role_id, version_number, opal_domain_id, role_name, is_active, application_function_list)
-VALUES (1,1, 1, 'Fines_Role_1', true, ARRAY['CREATE_MANAGE_DRAFT_ACCOUNTS', 'ACCOUNT_ENQUIRY_NOTES']),
-       (1,2, 1, 'Fines_Role_1', true, ARRAY['CREATE_MANAGE_DRAFT_ACCOUNTS', 'ACCOUNT_ENQUIRY']),
-       (2,1, 1, 'Fines_Role_2', true, ARRAY['COLLECTION_ORDER']),
-       (2,2, 1, 'Fines_Role_2', true, ARRAY['CHECK_VALIDATE_DRAFT_ACCOUNTS', 'SEARCH_AND_VIEW_ACCOUNTS']),
-       (2,3, 1, 'Fines_Role_2', true, ARRAY['COLLECTION_ORDER', 'CHECK_VALIDATE_DRAFT_ACCOUNTS', 'SEARCH_AND_VIEW_ACCOUNTS']),
-       (3,1, 2, 'Confiscation_Role_3', true, ARRAY['CREATE_MANAGE_DRAFT_ACCOUNTS']),
-       (3,2, 2, 'Confiscation_Role_3', true, ARRAY['CREATE_MANAGE_DRAFT_ACCOUNTS', 'COLLECTION_ORDER']);
+VALUES (1,1, 1, 'Fines_Role_1', true, ARRAY['Create and Manage Draft Accounts', 'Account Enquiry - Account Notes']),
+       (1,2, 1, 'Fines_Role_1', true, ARRAY['Create and Manage Draft Accounts', 'Account Enquiry']),
+       (2,1, 1, 'Fines_Role_2', true, ARRAY['Collection Order']),
+       (2,2, 1, 'Fines_Role_2', true, ARRAY['Check and Validate Draft Accounts', 'Search and View Accounts']),
+       (2,3, 1, 'Fines_Role_2', true, ARRAY['Collection Order', 'Check and Validate Draft Accounts', 'Search and View Accounts']),
+       (3,1, 2, 'Confiscation_Role_3', true, ARRAY['Create and Manage Draft Accounts']),
+       (3,2, 2, 'Confiscation_Role_3', true, ARRAY['Create and Manage Draft Accounts', 'Collection Order']);
 
 INSERT INTO business_unit_user_roles(business_unit_user_role_id, business_unit_user_id, role_id)
 VALUES (1,'L065JG', 1),

--- a/src/main/java/uk/gov/hmcts/reform/opal/authorisation/model/Permissions.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/authorisation/model/Permissions.java
@@ -41,12 +41,13 @@ public enum Permissions {
         };
     }
 
-    public static Permissions toPermissionOrNull(String function) {
-        try {
-            return Permissions.valueOf(function);
-        } catch (IllegalArgumentException e) {
-            log.error("Permission could not be mapped: {}", function);
-            return null;
+    public static Permissions toPermissionOrNull(String functionDescription) {
+        for (Permissions permission : Permissions.values()) {
+            if (permission.description.equals(functionDescription)) {
+                return permission;
+            }
         }
+        log.error("Permission could not be mapped: {}", functionDescription);
+        return null;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/opal/entity/BusinessUnitUserEntity.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/entity/BusinessUnitUserEntity.java
@@ -16,6 +16,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -30,11 +31,13 @@ import java.util.Set;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
 @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "businessUnitUserId")
+@ToString(onlyExplicitlyIncluded = true)
 public class BusinessUnitUserEntity {
 
     @Id
     @Column(name = "business_unit_user_id", length = 6)
     @EqualsAndHashCode.Include
+    @ToString.Include
     private String businessUnitUserId;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/test/java/uk/gov/hmcts/reform/opal/authorisation/model/PermissionsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/opal/authorisation/model/PermissionsTest.java
@@ -8,13 +8,13 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 class PermissionsTest {
 
     @Test
-    void toPermissionOrNull_returnsPermissionForValidFunctionName() {
-        Permissions permission = Permissions.toPermissionOrNull("ACCOUNT_ENQUIRY");
+    void toPermissionOrNull_returnsPermissionForValidDescription() {
+        Permissions permission = Permissions.toPermissionOrNull(Permissions.ACCOUNT_ENQUIRY.description);
         assertEquals(Permissions.ACCOUNT_ENQUIRY, permission);
     }
 
     @Test
-    void toPermissionOrNull_returnsNullForInvalidFunctionName() {
+    void toPermissionOrNull_returnsNullForInvalidDescription() {
         Permissions permission = Permissions.toPermissionOrNull("NOT_A_PERMISSION");
         assertNull(permission);
     }

--- a/src/test/java/uk/gov/hmcts/reform/opal/mappers/UserStateMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/opal/mappers/UserStateMapperTest.java
@@ -42,11 +42,11 @@ class UserStateMapperTest {
     DomainEntity fines = DomainEntity.builder().name("fines").build();
     DomainEntity confiscations = DomainEntity.builder().name("confiscation").build();
 
-    String permAE = Permissions.ACCOUNT_ENQUIRY.name();
-    String permAEN = Permissions.ACCOUNT_ENQUIRY_NOTES.name();
-    String permCVDA = Permissions.CHECK_VALIDATE_DRAFT_ACCOUNTS.name();
-    String permCO = Permissions.COLLECTION_ORDER.name();
-    String permSAVA = Permissions.SEARCH_AND_VIEW_ACCOUNTS.name();
+    String permAE = Permissions.ACCOUNT_ENQUIRY.description;
+    String permAEN = Permissions.ACCOUNT_ENQUIRY_NOTES.description;
+    String permCVDA = Permissions.CHECK_VALIDATE_DRAFT_ACCOUNTS.description;
+    String permCO = Permissions.COLLECTION_ORDER.description;
+    String permSAVA = Permissions.SEARCH_AND_VIEW_ACCOUNTS.description;
     String permBadName = "BAD_NAME";
 
     LocalDateTime nowUtc = LocalDateTime.ofInstant(clock.instant(), ZoneOffset.UTC);


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/PO-2833

Fixing a permissions bug to allow testing of the above ticket.

Changes:
1. insert_authorisation_data.sql now has the correct type of permission names. Now inline with that used in user db migration scripts. 'CREATE_MANAGE_DRAFT_ACCOUNTS' -> 'Create and Manage Draft Accounts'
2. Permissions#toPermissionOrNull needed amending so the description is used.
3. BusinessUnitUserEntity toString updated to stop stackoverflows
4. Fixed issue in UserPermissionsControllerGetIntegrationTest where JSON wasn't being compared correctly
