### PR TITLE
PO-3923 : Search permissions not coming through

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/UserPermissionsControllerGetIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/UserPermissionsControllerGetIntegrationTest.java
@@ -590,7 +590,7 @@ class UserPermissionsControllerGetIntegrationTest extends AbstractIntegrationTes
                   "permission_name" : "Check and Validate Draft Accounts"
                 }, {
                   "permission_id" : 6,
-                  "permission_name" : "Search and View Accounts"
+                  "permission_name" : "Search and view accounts"
                 } ]
               }, {
                 "business_unit_user_id" : "L066JG",

--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/repository/RoleRepositoryIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/repository/RoleRepositoryIntegrationTest.java
@@ -37,7 +37,7 @@ class RoleRepositoryIntegrationTest extends BaseIntegrationTest {
             "Create and Manage Draft Accounts", "Account Enquiry");
         assertThat(finesRole2.getVersionNumber()).isEqualTo(3);
         assertThat(finesRole2.getApplicationFunctionList()).containsExactly(
-            "Collection Order", "Check and Validate Draft Accounts", "Search and View Accounts");
+            "Collection Order", "Check and Validate Draft Accounts", "Search and view accounts");
         assertThat(confiscationRole3.getVersionNumber()).isEqualTo(2);
         assertThat(confiscationRole3.getApplicationFunctionList()).containsExactly(
             "Create and Manage Draft Accounts", "Collection Order");

--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/repository/UserRepositoryIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/repository/UserRepositoryIntegrationTest.java
@@ -102,7 +102,7 @@ class UserRepositoryIntegrationTest extends BaseIntegrationTest {
                         },
                         {
                           "permission_id": 6,
-                          "permission_name": "Search and View Accounts"
+                          "permission_name": "Search and view accounts"
                         }
                       ]
                     },

--- a/src/integrationTest/resources/db.insertData/insert_authorisation_data.sql
+++ b/src/integrationTest/resources/db.insertData/insert_authorisation_data.sql
@@ -61,8 +61,8 @@ INSERT INTO roles (role_id, version_number, opal_domain_id, role_name, is_active
 VALUES (1,1, 1, 'Fines_Role_1', true, ARRAY['Create and Manage Draft Accounts', 'Account Enquiry - Account Notes']),
        (1,2, 1, 'Fines_Role_1', true, ARRAY['Create and Manage Draft Accounts', 'Account Enquiry']),
        (2,1, 1, 'Fines_Role_2', true, ARRAY['Collection Order']),
-       (2,2, 1, 'Fines_Role_2', true, ARRAY['Check and Validate Draft Accounts', 'Search and View Accounts']),
-       (2,3, 1, 'Fines_Role_2', true, ARRAY['Collection Order', 'Check and Validate Draft Accounts', 'Search and View Accounts']),
+       (2,2, 1, 'Fines_Role_2', true, ARRAY['Check and Validate Draft Accounts', 'Search and view accounts']),
+       (2,3, 1, 'Fines_Role_2', true, ARRAY['Collection Order', 'Check and Validate Draft Accounts', 'Search and view accounts']),
        (3,1, 2, 'Confiscation_Role_3', true, ARRAY['Create and Manage Draft Accounts']),
        (3,2, 2, 'Confiscation_Role_3', true, ARRAY['Create and Manage Draft Accounts', 'Collection Order']);
 

--- a/src/main/java/uk/gov/hmcts/reform/opal/authorisation/model/Permissions.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/authorisation/model/Permissions.java
@@ -11,7 +11,7 @@ public enum Permissions {
     ACCOUNT_ENQUIRY(3, "Account Enquiry"),
     COLLECTION_ORDER(4, "Collection Order"),
     CHECK_VALIDATE_DRAFT_ACCOUNTS(5, "Check and Validate Draft Accounts"),
-    SEARCH_AND_VIEW_ACCOUNTS(6, "Search and View Accounts");
+    SEARCH_AND_VIEW_ACCOUNTS(6, "Search and view accounts");
     public static final Permissions[] DRAFT_ACCOUNT_PERMISSIONS = {
         CREATE_MANAGE_DRAFT_ACCOUNTS, CHECK_VALIDATE_DRAFT_ACCOUNTS
     };

--- a/src/test/java/uk/gov/hmcts/reform/opal/mappers/UserStateMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/opal/mappers/UserStateMapperTest.java
@@ -125,7 +125,7 @@ class UserStateMapperTest {
                         },
                         {
                           "permission_id": 6,
-                          "permission_name": "Search and View Accounts"
+                          "permission_name": "Search and view accounts"
                         }
                       ]
                     }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/PO-3923
"SEARCH_AND_VIEW_ACCOUNTS permission not included in V2 UserState"

The permission description of the enum was not aligned with the permission in the database:
 "Search and View Accounts" !=  "Search and view accounts"