### PR TITLE
PO-6363: Restrict V2 user state endpoint to authenticated user

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/UserPermissionsControllerGetIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/UserPermissionsControllerGetIntegrationTest.java
@@ -126,6 +126,42 @@ class UserPermissionsControllerGetIntegrationTest extends AbstractIntegrationTes
         assertThat(ttl).isBetween(29L, 30L); //30 mins TTL seems to immediately tick down to 29 mins.
     }
 
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    @DisplayName("PO-2816, AC3: V2 with ID should update last_login_date only when newLogin is true")
+    void getV2UserStateWithId_updatesLastLoginDateInDb(boolean newLogin) throws Exception {
+        long userIdWithPermissions = 500000000L;
+        LocalDateTime existingLastLoginDate = LocalDateTime.parse("2026-04-10T09:00:00");
+
+        String subject = "k9LpT2xVqR8m";
+        Authentication auth = createJwtPrincipal(subject, "opal-test@HMCTS.NET", "Pablo");
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        updateLastLoginDate(userIdWithPermissions, existingLastLoginDate);
+        try {
+            LocalDateTime before = readLastLoginDate(userIdWithPermissions);
+            assertThat(before).isEqualTo(existingLastLoginDate);
+
+            MockHttpServletRequestBuilder builder = get(V2_CURRENT_USER_STATE_URI);
+            addLoginHeader(newLogin, builder);
+
+            mockMvc.perform(builder)
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+
+            LocalDateTime after = readLastLoginDate(userIdWithPermissions);
+
+            if (newLogin) {
+                assertThat(after).isNotNull();
+                assertThat(after).isAfter(before);
+            } else {
+                assertThat(after).isEqualTo(before);
+            }
+        } finally {
+            clearLastLoginDate(userIdWithPermissions);
+        }
+    }
+
     @Test
     @DisplayName("PO-2835 AC2: should refresh cached user state and TTL")
     void getV2UserStateViaPrincipal_refreshesTtlOfRedisEntry() throws Exception {
@@ -161,10 +197,57 @@ class UserPermissionsControllerGetIntegrationTest extends AbstractIntegrationTes
         assertThat(ttlBeforeRefreshMinutes3).isBetween(29L, 30L);
     }
 
+    @Test
+    @DisplayName("PO-2835 AC3: cached user state should expire and return no data")
+    void getV2UserState_cachedStateExpiresAfterTtl() throws Exception {
+        String subject = "k9LpT2xVqR8m";
+        String cacheKey = "USER_STATE_" + subject;
+        Authentication auth = createJwtPrincipal(subject, "opal-test@HMCTS.NET", "Pablo");
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        // Populate cache by calling the API with valid data.
+        mockMvc.perform(get(V2_CURRENT_USER_STATE_URI))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+
+        JsonNode expectedNode = expectedV2UserState(false);
+        JsonNode actualNode = objectMapper.readTree(redisTemplate.opsForValue().get(cacheKey));
+        assertThat(actualNode).isEqualTo(expectedNode);
+
+        // Simulate "30 minutes later"
+        Boolean ttlSet = redisTemplate.expire(cacheKey, 1, TimeUnit.SECONDS);
+        assertThat(ttlSet).isTrue();
+
+        // Poll until the entry disappears from Redis
+        String cachedValue = redisTemplate.opsForValue().get(cacheKey);
+        long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (cachedValue != null && System.nanoTime() < deadlineNanos) {
+            Thread.sleep(100L);
+            cachedValue = redisTemplate.opsForValue().get(cacheKey);
+        }
+
+        assertThat(cachedValue).isNull();
+    }
+
     private LocalDateTime readLastLoginDate(long userId) {
         return jdbcTemplate.queryForObject(
             "select last_login_date from users where user_id = ?",
             (rs, rowNum) -> rs.getObject("last_login_date", LocalDateTime.class),
+            userId
+        );
+    }
+
+    private void updateLastLoginDate(long userId, LocalDateTime lastLoginDate) {
+        jdbcTemplate.update(
+            "update users set last_login_date = ? where user_id = ?",
+            lastLoginDate,
+            userId
+        );
+    }
+
+    private void clearLastLoginDate(long userId) {
+        jdbcTemplate.update(
+            "update users set last_login_date = null where user_id = ?",
             userId
         );
     }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/UserPermissionsControllerGetIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/UserPermissionsControllerGetIntegrationTest.java
@@ -55,6 +55,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class UserPermissionsControllerGetIntegrationTest extends AbstractIntegrationTest {
 
     private static final String URL_BASE = "/users";
+    private static final String V2_CURRENT_USER_STATE_URI = "/v2" + URL_BASE + "/0/state";
     private static final String X_NEW_LOGIN = "X-New-Login";
 
     @MockitoSpyBean
@@ -87,7 +88,7 @@ class UserPermissionsControllerGetIntegrationTest extends AbstractIntegrationTes
         String cacheKey = "USER_STATE_" + subject;
         redisTemplate.delete(cacheKey);
 
-        MockHttpServletRequestBuilder builder = get("/v2" + URL_BASE + "/" + userIdWithPermissions + "/state");
+        MockHttpServletRequestBuilder builder = get(V2_CURRENT_USER_STATE_URI);
         addLoginHeader(newLogin, builder);
         ResultActions actions = mockMvc.perform(builder);
 
@@ -125,36 +126,6 @@ class UserPermissionsControllerGetIntegrationTest extends AbstractIntegrationTes
         assertThat(ttl).isBetween(29L, 30L); //30 mins TTL seems to immediately tick down to 29 mins.
     }
 
-    @ParameterizedTest
-    @ValueSource(booleans = {false, true})
-    @DisplayName("PO-2816, AC3: V2 with ID should update last_login_date only when newLogin is true")
-    void getV2UserStateWithId_updatesLastLoginDateInDb(boolean newLogin) throws Exception {
-        long userIdWithPermissions = 500000000L;
-
-        String subject = "k9LpT2xVqR8m";
-        Authentication auth = createJwtPrincipal(subject, "opal-test@HMCTS.NET", "Pablo");
-        SecurityContextHolder.getContext().setAuthentication(auth);
-
-        LocalDateTime before = readLastLoginDate(userIdWithPermissions);
-
-        MockHttpServletRequestBuilder builder =
-            get("/v2" + URL_BASE + "/" + userIdWithPermissions + "/state");
-        addLoginHeader(newLogin, builder);
-
-        mockMvc.perform(builder)
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON));
-
-        LocalDateTime after = readLastLoginDate(userIdWithPermissions);
-
-        if (newLogin) {
-            assertThat(after).isNotNull();
-            assertThat(after).isAfter(before);
-        } else {
-            assertThat(after).isEqualTo(before);
-        }
-    }
-
     @Test
     @DisplayName("PO-2835 AC2: should refresh cached user state and TTL")
     void getV2UserStateViaPrincipal_refreshesTtlOfRedisEntry() throws Exception {
@@ -165,7 +136,7 @@ class UserPermissionsControllerGetIntegrationTest extends AbstractIntegrationTes
         SecurityContextHolder.getContext().setAuthentication(auth);
 
         //call once, check we have the initial TTL
-        ResultActions firstCall = mockMvc.perform(get("/v2" + URL_BASE + "/" + userId + "/state"))
+        ResultActions firstCall = mockMvc.perform(get(V2_CURRENT_USER_STATE_URI))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON));
         String firstBody = firstCall.andReturn().getResponse().getContentAsString();
@@ -180,7 +151,7 @@ class UserPermissionsControllerGetIntegrationTest extends AbstractIntegrationTes
         assertThat(ttlBeforeRefreshMinutes2).isBetween(4L, 5L);
 
         //call a second time and check we get the new TTL.
-        ResultActions secondCall = mockMvc.perform(get("/v2" + URL_BASE + "/" + userId + "/state"))
+        ResultActions secondCall = mockMvc.perform(get(V2_CURRENT_USER_STATE_URI))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON));
         String secondBody = secondCall.andReturn().getResponse().getContentAsString();
@@ -188,39 +159,6 @@ class UserPermissionsControllerGetIntegrationTest extends AbstractIntegrationTes
             .isEqualTo(objectMapper.readTree(secondBody));
         Long ttlBeforeRefreshMinutes3 = redisTemplate.getExpire(cacheKey, TimeUnit.MINUTES);
         assertThat(ttlBeforeRefreshMinutes3).isBetween(29L, 30L);
-    }
-
-    @Test
-    @DisplayName("PO-2835 AC3: cached user state should expire and return no data")
-    void getV2UserStateWithId_cachedStateExpiresAfterTtl() throws Exception {
-        long userId = 500000000L;
-        String subject = "k9LpT2xVqR8m";
-        String cacheKey = "USER_STATE_" + subject;
-        Authentication auth = createJwtPrincipal(subject, "opal-test@HMCTS.NET", "Pablo");
-        SecurityContextHolder.getContext().setAuthentication(auth);
-
-        // Populate cache by calling the API with valid data.
-        mockMvc.perform(get("/v2" + URL_BASE + "/" + userId + "/state"))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON));
-
-        JsonNode expectedNode = expectedV2UserState(false);
-        JsonNode actualNode = objectMapper.readTree(redisTemplate.opsForValue().get(cacheKey));
-        assertThat(actualNode).isEqualTo(expectedNode);
-
-        // Simulate "30 minutes later"
-        Boolean ttlSet = redisTemplate.expire(cacheKey, 1, TimeUnit.SECONDS);
-        assertThat(ttlSet).isTrue();
-
-        // Poll until the entry disappears from Redis
-        String cachedValue = redisTemplate.opsForValue().get(cacheKey);
-        long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
-        while (cachedValue != null && System.nanoTime() < deadlineNanos) {
-            Thread.sleep(100L);
-            cachedValue = redisTemplate.opsForValue().get(cacheKey);
-        }
-
-        assertThat(cachedValue).isNull();
     }
 
     private LocalDateTime readLastLoginDate(long userId) {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/UserPermissionsControllerGetIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/UserPermissionsControllerGetIntegrationTest.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -42,15 +41,15 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_CLASS;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ActiveProfiles({"integration", "opal"})
 @Slf4j(topic = "opal.UserPermissionsControllerIntegrationTest")
-@Sql(scripts = "classpath:db.reset/clean_test_data.sql", executionPhase = BEFORE_TEST_CLASS)
-@Sql(scripts = "classpath:db.insertData/insert_authorisation_data.sql", executionPhase = BEFORE_TEST_CLASS)
+@Sql(scripts = "classpath:db.reset/clean_test_data.sql", executionPhase = BEFORE_TEST_METHOD)
+@Sql(scripts = "classpath:db.insertData/insert_authorisation_data.sql", executionPhase = BEFORE_TEST_METHOD)
 @DisplayName("UserPermissionsControllerGetIntegrationTest")
 class UserPermissionsControllerGetIntegrationTest extends AbstractIntegrationTest {
 
@@ -64,15 +63,6 @@ class UserPermissionsControllerGetIntegrationTest extends AbstractIntegrationTes
     @Autowired
     StringRedisTemplate redisTemplate;
 
-    @BeforeEach
-    void resetLastLoginDate() {
-        jdbcTemplate.update(
-            "update users set last_login_date = ? where user_id = ?",
-            java.sql.Timestamp.valueOf(LocalDateTime.of(2026, 4, 14, 10, 15, 30)),
-            500000000L
-        );
-    }
-
     private ObjectMapper objectMapper = new ObjectMapper();
 
 
@@ -80,7 +70,6 @@ class UserPermissionsControllerGetIntegrationTest extends AbstractIntegrationTes
     @ValueSource(booleans = {false, true})
     @DisplayName("V2 with ID Should return 200 and full V2 user state for a user with permissions")
     void getV2UserStateWithId_returnsFullState(boolean newLogin) throws Exception {
-        long userIdWithPermissions = 500000000L;
         String subject = "k9LpT2xVqR8m";
         Authentication auth = createJwtPrincipal(subject,"opal-test@HMCTS.NET", "Pablo");
         SecurityContextHolder.getContext().setAuthentication(auth);
@@ -138,34 +127,29 @@ class UserPermissionsControllerGetIntegrationTest extends AbstractIntegrationTes
         SecurityContextHolder.getContext().setAuthentication(auth);
 
         updateLastLoginDate(userIdWithPermissions, existingLastLoginDate);
-        try {
-            LocalDateTime before = readLastLoginDate(userIdWithPermissions);
-            assertThat(before).isEqualTo(existingLastLoginDate);
+        LocalDateTime before = readLastLoginDate(userIdWithPermissions);
+        assertThat(before).isEqualTo(existingLastLoginDate);
 
-            MockHttpServletRequestBuilder builder = get(V2_CURRENT_USER_STATE_URI);
-            addLoginHeader(newLogin, builder);
+        MockHttpServletRequestBuilder builder = get(V2_CURRENT_USER_STATE_URI);
+        addLoginHeader(newLogin, builder);
 
-            mockMvc.perform(builder)
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+        mockMvc.perform(builder)
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON));
 
-            LocalDateTime after = readLastLoginDate(userIdWithPermissions);
+        LocalDateTime after = readLastLoginDate(userIdWithPermissions);
 
-            if (newLogin) {
-                assertThat(after).isNotNull();
-                assertThat(after).isAfter(before);
-            } else {
-                assertThat(after).isEqualTo(before);
-            }
-        } finally {
-            clearLastLoginDate(userIdWithPermissions);
+        if (newLogin) {
+            assertThat(after).isNotNull();
+            assertThat(after).isAfter(before);
+        } else {
+            assertThat(after).isEqualTo(before);
         }
     }
 
     @Test
     @DisplayName("PO-2835 AC2: should refresh cached user state and TTL")
     void getV2UserStateViaPrincipal_refreshesTtlOfRedisEntry() throws Exception {
-        long userId = 500000000L;
         String subject = "k9LpT2xVqR8m";
         String cacheKey = "USER_STATE_" + subject;
         Authentication auth = createJwtPrincipal(subject, "opal-test@HMCTS.NET", "Pablo");
@@ -241,13 +225,6 @@ class UserPermissionsControllerGetIntegrationTest extends AbstractIntegrationTes
         jdbcTemplate.update(
             "update users set last_login_date = ? where user_id = ?",
             lastLoginDate,
-            userId
-        );
-    }
-
-    private void clearLastLoginDate(long userId) {
-        jdbcTemplate.update(
-            "update users set last_login_date = null where user_id = ?",
             userId
         );
     }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/UserPermissionsV2LegacySyncIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/UserPermissionsV2LegacySyncIntegrationTest.java
@@ -37,7 +37,7 @@ import static uk.gov.hmcts.reform.opal.entity.BusinessEventLogType.ROLE_UNASSIGN
 @DisplayName("UserPermissionsV2 legacy synchronisation integration tests")
 class UserPermissionsV2LegacySyncIntegrationTest extends AbstractLegacyWireMockIntegrationTest {
 
-    private static final long USER_ID = 500000001L; // seeded with no permissions
+    private static final long USER_ID = 500000003L; // seeded with no permissions
     private static final long USER_WITH_EXISTING_ROLE = 500000000L;
     private static final long DIFFERENT_USER_ID = 500000006L;
     private static final short BUSINESS_UNIT_ID = 69;
@@ -46,6 +46,7 @@ class UserPermissionsV2LegacySyncIntegrationTest extends AbstractLegacyWireMockI
     private static final String EXISTING_BUSINESS_UNIT_USER_ID = "L081JG";
     private static final long ROLE_ID = 1L;
     private static final String ROLE_MAPPING_USER_PREFIX = "ROLE_MAPPING_USER_";
+    private static final String CURRENT_USER_STATE_URI = "/v2/users/0/state";
 
     @Autowired
     private UserRepository userRepository;
@@ -64,7 +65,7 @@ class UserPermissionsV2LegacySyncIntegrationTest extends AbstractLegacyWireMockI
     @DisplayName("AC1/AC13: should remove roles and keep activation date unset when legacy returns no BU data")
     void getUserStateV2_whenLegacyReturnsNoData_removesAllRoles() throws Exception {
         UserEntity user = userRepository.findById(USER_WITH_EXISTING_ROLE).orElseThrow();
-        TestHelperUtil.setAuthenticatedUser(user.getTokenSubject());
+        TestHelperUtil.setAuthenticatedUser(user);
         assertThat(helper.getActivationDate(user.getUserId())).isNull();
         long roleCountBefore = helper.countRoleAssignments(user.getUserId());
         legacyWireMockXmlStubHelper.registerSystemUserLookupStub(List.of(), 1);
@@ -76,7 +77,7 @@ class UserPermissionsV2LegacySyncIntegrationTest extends AbstractLegacyWireMockI
 
         assertThat(roleCountBefore).isGreaterThan(0L);
 
-        mockMvc.perform(get(userStateUri(user.getUserId())))
+        mockMvc.perform(get(CURRENT_USER_STATE_URI))
             .andExpect(status().isOk());
 
         assertThat(helper.countRoleAssignments(user.getUserId())).isEqualTo(0L);
@@ -88,7 +89,7 @@ class UserPermissionsV2LegacySyncIntegrationTest extends AbstractLegacyWireMockI
     @DisplayName("AC2: should create missing BUU and assign role from cache when legacy returns BUU")
     void getUserStateV2_createsMissingBusinessUnitUserAndAssignsRole() throws Exception {
         UserEntity user = userRepository.findById(USER_ID).orElseThrow();
-        TestHelperUtil.setAuthenticatedUser(user.getTokenSubject());
+        TestHelperUtil.setAuthenticatedUser(user);
         legacyWireMockXmlStubHelper.registerBusinessUnitUserLookupStub(
             List.of(TestHelperUtil.legacyBusinessUnitUser(BUSINESS_UNIT_USER_ID, BUSINESS_UNIT_ID))
         );
@@ -96,7 +97,7 @@ class UserPermissionsV2LegacySyncIntegrationTest extends AbstractLegacyWireMockI
 
         assertThat(helper.businessUnitUserExists(BUSINESS_UNIT_USER_ID)).isFalse();
 
-        mockMvc.perform(get(userStateUri(user.getUserId())));
+        mockMvc.perform(get(CURRENT_USER_STATE_URI));
 
         helper.assertBusinessUnitUserRow(BUSINESS_UNIT_USER_ID, BUSINESS_UNIT_ID, USER_ID, ROLE_ID, 1L);
         assertThat(helper.getLoggedBusinessEventTypes()).containsExactly(
@@ -109,7 +110,7 @@ class UserPermissionsV2LegacySyncIntegrationTest extends AbstractLegacyWireMockI
     @DisplayName("AC3: should reassign existing BUU to the requested user and assign role from cache")
     void getUserStateV2_reassignsExistingBusinessUnitUserToRequestedUser() throws Exception {
         UserEntity user = userRepository.findById(USER_ID).orElseThrow();
-        TestHelperUtil.setAuthenticatedUser(user.getTokenSubject());
+        TestHelperUtil.setAuthenticatedUser(user);
         legacyWireMockXmlStubHelper.registerBusinessUnitUserLookupStub(
             List.of(TestHelperUtil.legacyBusinessUnitUser(EXISTING_BUSINESS_UNIT_USER_ID, LEGACY_BUSINESS_UNIT_ID))
         );
@@ -117,7 +118,7 @@ class UserPermissionsV2LegacySyncIntegrationTest extends AbstractLegacyWireMockI
 
         helper.assertBusinessUnitUserRow(EXISTING_BUSINESS_UNIT_USER_ID, LEGACY_BUSINESS_UNIT_ID, DIFFERENT_USER_ID);
 
-        mockMvc.perform(get(userStateUri(user.getUserId())))
+        mockMvc.perform(get(CURRENT_USER_STATE_URI))
             .andExpect(status().isOk());
 
         helper.assertBusinessUnitUserRow(EXISTING_BUSINESS_UNIT_USER_ID, LEGACY_BUSINESS_UNIT_ID, USER_ID, ROLE_ID, 1L);
@@ -131,7 +132,7 @@ class UserPermissionsV2LegacySyncIntegrationTest extends AbstractLegacyWireMockI
     @DisplayName("AC4: should update BU on existing BUU and assign role from cache")
     void getUserStateV2_updatesBusinessUnitIdOnExistingBusinessUnitUser() throws Exception {
         UserEntity user = userRepository.findById(USER_ID).orElseThrow();
-        TestHelperUtil.setAuthenticatedUser(user.getTokenSubject());
+        TestHelperUtil.setAuthenticatedUser(user);
         helper.updateBusinessUnitUser(EXISTING_BUSINESS_UNIT_USER_ID, LEGACY_BUSINESS_UNIT_ID, USER_ID);
         legacyWireMockXmlStubHelper.registerBusinessUnitUserLookupStub(
             List.of(TestHelperUtil.legacyBusinessUnitUser(EXISTING_BUSINESS_UNIT_USER_ID, BUSINESS_UNIT_ID))
@@ -140,7 +141,7 @@ class UserPermissionsV2LegacySyncIntegrationTest extends AbstractLegacyWireMockI
 
         helper.assertBusinessUnitUserRow(EXISTING_BUSINESS_UNIT_USER_ID, LEGACY_BUSINESS_UNIT_ID, USER_ID);
 
-        mockMvc.perform(get(userStateUri(user.getUserId())))
+        mockMvc.perform(get(CURRENT_USER_STATE_URI))
             .andExpect(status().isOk());
 
         helper.assertBusinessUnitUserRow(EXISTING_BUSINESS_UNIT_USER_ID, BUSINESS_UNIT_ID, USER_ID, ROLE_ID, 1L);
@@ -154,7 +155,7 @@ class UserPermissionsV2LegacySyncIntegrationTest extends AbstractLegacyWireMockI
     @DisplayName("AC5/AC12: should return valid state, remove roles, and keep activation date unset when cache miss")
     void getUserStateV2_whenRoleMappingCacheEntryMissing_removesAllRoles() throws Exception {
         UserEntity user = userRepository.findById(USER_ID).orElseThrow();
-        TestHelperUtil.setAuthenticatedUser(user.getTokenSubject());
+        TestHelperUtil.setAuthenticatedUser(user);
         assertThat(helper.getActivationDate(user.getUserId())).isNull();
         helper.updateBusinessUnitUser(EXISTING_BUSINESS_UNIT_USER_ID, LEGACY_BUSINESS_UNIT_ID, USER_ID);
         legacyWireMockXmlStubHelper.registerBusinessUnitUserLookupStub(
@@ -165,7 +166,7 @@ class UserPermissionsV2LegacySyncIntegrationTest extends AbstractLegacyWireMockI
 
         assertThat(roleCountBefore).isGreaterThan(0L);
 
-        mockMvc.perform(get(userStateUri(user.getUserId())))
+        mockMvc.perform(get(CURRENT_USER_STATE_URI))
             .andExpect(status().isOk());
 
         assertThat(helper.countRoleAssignments(user.getUserId())).isEqualTo(0L);
@@ -183,7 +184,7 @@ class UserPermissionsV2LegacySyncIntegrationTest extends AbstractLegacyWireMockI
         final short buId3NotReturnedByLegacy = 68;
 
         UserEntity user = userRepository.findById(USER_ID).orElseThrow();
-        TestHelperUtil.setAuthenticatedUser(user.getTokenSubject());
+        TestHelperUtil.setAuthenticatedUser(user);
         helper.insertBusinessUnitUser(buuId1, buId1, USER_ID);
         helper.insertBusinessUnitUser(buuId2, buId2, USER_ID);
         helper.insertBusinessUnitUserRole(buuId1, ROLE_ID);
@@ -198,7 +199,7 @@ class UserPermissionsV2LegacySyncIntegrationTest extends AbstractLegacyWireMockI
             ROLE_MAPPING_USER_PREFIX
         );
 
-        mockMvc.perform(get(userStateUri(user.getUserId())))
+        mockMvc.perform(get(CURRENT_USER_STATE_URI))
             .andExpect(status().isOk());
 
         helper.assertUserBusinessUnitIds(user.getUserId(), buId1, buId2);
@@ -227,7 +228,7 @@ class UserPermissionsV2LegacySyncIntegrationTest extends AbstractLegacyWireMockI
         final short buId3 = 68;
 
         UserEntity user = userRepository.findById(USER_ID).orElseThrow();
-        TestHelperUtil.setAuthenticatedUser(user.getTokenSubject());
+        TestHelperUtil.setAuthenticatedUser(user);
         assertThat(helper.getActivationDate(user.getUserId())).isNull();
         helper.insertBusinessUnitUser(buuId1, buId1, USER_ID);
         helper.insertBusinessUnitUser(buuId2, buId2, USER_ID);
@@ -242,7 +243,7 @@ class UserPermissionsV2LegacySyncIntegrationTest extends AbstractLegacyWireMockI
         helper.setRoleMappingCache(user, roleMappingCache, ROLE_MAPPING_USER_PREFIX);
 
         //assertions on the response verify changes from the inner transaction are visible to outer calling code
-        mockMvc.perform(get(userStateUri(user.getUserId())))
+        mockMvc.perform(get(CURRENT_USER_STATE_URI))
             .andExpect(status().isOk())
             .andExpect(jsonPath(
                 "$.domains.*.business_unit_users[*].business_unit_id",
@@ -275,7 +276,7 @@ class UserPermissionsV2LegacySyncIntegrationTest extends AbstractLegacyWireMockI
         final long roleNotInCache = 2L;
 
         UserEntity user = userRepository.findById(USER_ID).orElseThrow();
-        TestHelperUtil.setAuthenticatedUser(user.getTokenSubject());
+        TestHelperUtil.setAuthenticatedUser(user);
         helper.insertBusinessUnitUser(buuId1, buId1, USER_ID);
         helper.insertBusinessUnitUser(buuId2, buId2, USER_ID);
         helper.insertBusinessUnitUserRole(buuId1, roleNotInCache);
@@ -290,7 +291,7 @@ class UserPermissionsV2LegacySyncIntegrationTest extends AbstractLegacyWireMockI
             ROLE_MAPPING_USER_PREFIX
         );
 
-        mockMvc.perform(get(userStateUri(user.getUserId())))
+        mockMvc.perform(get(CURRENT_USER_STATE_URI))
             .andExpect(status().isOk());
 
         helper.assertUserBusinessUnitIds(user.getUserId(), buId1, buId2, buId3);
@@ -317,7 +318,7 @@ class UserPermissionsV2LegacySyncIntegrationTest extends AbstractLegacyWireMockI
         final LocalDateTime existingActivationDate = LocalDateTime.parse("2025-01-02T03:04:05.678");
 
         UserEntity user = userRepository.findById(USER_ID).orElseThrow();
-        TestHelperUtil.setAuthenticatedUser(user.getTokenSubject());
+        TestHelperUtil.setAuthenticatedUser(user);
         helper.updateUserActivationDate(user.getUserId(), existingActivationDate);
         helper.insertBusinessUnitUser(buuId1, buId1, USER_ID);
         helper.insertBusinessUnitUser(buuId2, buId2, USER_ID);
@@ -331,7 +332,7 @@ class UserPermissionsV2LegacySyncIntegrationTest extends AbstractLegacyWireMockI
         Map<Long, Set<Short>> roleMappingCache = Map.of(ROLE_ID, Set.of(buId1, buId2, buId3));
         helper.setRoleMappingCache(user, roleMappingCache, ROLE_MAPPING_USER_PREFIX);
 
-        mockMvc.perform(get(userStateUri(user.getUserId())))
+        mockMvc.perform(get(CURRENT_USER_STATE_URI))
             .andExpect(status().isOk());
 
         helper.assertUserBusinessUnitIds(user.getUserId(), buId1, buId2, buId3);
@@ -360,7 +361,7 @@ class UserPermissionsV2LegacySyncIntegrationTest extends AbstractLegacyWireMockI
         final long thirdRoleId = 3L;
 
         UserEntity user = userRepository.findById(USER_ID).orElseThrow();
-        TestHelperUtil.setAuthenticatedUser(user.getTokenSubject());
+        TestHelperUtil.setAuthenticatedUser(user);
         assertThat(helper.getActivationDate(user.getUserId())).isNull();
         helper.insertBusinessUnitUser(buuId1, buId1, USER_ID);
         helper.insertBusinessUnitUser(buuId2, buId2, USER_ID);
@@ -386,7 +387,7 @@ class UserPermissionsV2LegacySyncIntegrationTest extends AbstractLegacyWireMockI
             ROLE_MAPPING_USER_PREFIX
         );
 
-        mockMvc.perform(get(userStateUri(user.getUserId())))
+        mockMvc.perform(get(CURRENT_USER_STATE_URI))
             .andExpect(status().isOk());
 
         helper.assertUserBusinessUnitIds(user.getUserId(), buId1, buId2, buId3, buId4);
@@ -420,7 +421,7 @@ class UserPermissionsV2LegacySyncIntegrationTest extends AbstractLegacyWireMockI
     @DisplayName("Should roll back synchronisation when business event persistence fails")
     void getUserStateV2_whenBusinessEventPersistenceFails_rollsBackSynchronisation() throws Exception {
         UserEntity user = userRepository.findById(USER_ID).orElseThrow();
-        TestHelperUtil.setAuthenticatedUser(user.getTokenSubject());
+        TestHelperUtil.setAuthenticatedUser(user);
         assertThat(helper.getActivationDate(user.getUserId())).isNull();
         legacyWireMockXmlStubHelper.registerBusinessUnitUserLookupStub(
             List.of(TestHelperUtil.legacyBusinessUnitUser(BUSINESS_UNIT_USER_ID, BUSINESS_UNIT_ID))
@@ -430,7 +431,7 @@ class UserPermissionsV2LegacySyncIntegrationTest extends AbstractLegacyWireMockI
         assertThat(helper.businessUnitUserExists(BUSINESS_UNIT_USER_ID)).isFalse();
         long roleCountBefore = helper.countRoleAssignments(user.getUserId());
 
-        mockMvc.perform(get(userStateUri(user.getUserId())))
+        mockMvc.perform(get(CURRENT_USER_STATE_URI))
             .andExpect(status().isInternalServerError())
             .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(jsonPath("$.title").value("Internal Server Error"))
@@ -446,7 +447,4 @@ class UserPermissionsV2LegacySyncIntegrationTest extends AbstractLegacyWireMockI
         assertThat(helper.getLoggedBusinessEventTypes()).containsExactly(ROLE_ASSIGNED_TO_USER);
     }
 
-    private String userStateUri(long userId) {
-        return "/v2/users/" + userId + "/state";
-    }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/UserPermissionsV2OpalModeIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/UserPermissionsV2OpalModeIntegrationTest.java
@@ -37,10 +37,20 @@ class UserPermissionsV2OpalModeIntegrationTest extends AbstractIntegrationTest {
     @DisplayName("Should not trigger legacy synchronisation when app mode is opal")
     void getUserStateV2_whenAppModeIsOpal_doesNotSynchroniseWithLegacy() throws Exception {
         UserEntity user = userRepository.findById(USER_ID).orElseThrow();
-        TestHelperUtil.setAuthenticatedUser(user.getTokenSubject());
+        TestHelperUtil.setAuthenticatedUser(user);
+
+        mockMvc.perform(get("/v2/users/0/state"))
+            .andExpect(status().isOk());
+
+        verify(synchronisePermissionsService, never()).synchronise(any(UserEntity.class));
+    }
+
+    @Test
+    @DisplayName("Should reject non-zero user id requests")
+    void getUserStateV2_whenUserIdIsNonZero_returnsBadRequest() throws Exception {
 
         mockMvc.perform(get("/v2/users/" + USER_ID + "/state"))
-            .andExpect(status().isOk());
+            .andExpect(status().isBadRequest());
 
         verify(synchronisePermissionsService, never()).synchronise(any(UserEntity.class));
     }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/UserPermissionsV2OpalModeIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/UserPermissionsV2OpalModeIntegrationTest.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.opal.controllers;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.jdbc.Sql;
@@ -17,6 +18,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ActiveProfiles({"integration", "opal"})
@@ -50,7 +53,9 @@ class UserPermissionsV2OpalModeIntegrationTest extends AbstractIntegrationTest {
     void getUserStateV2_whenUserIdIsNonZero_returnsBadRequest() throws Exception {
 
         mockMvc.perform(get("/v2/users/" + USER_ID + "/state"))
-            .andExpect(status().isBadRequest());
+            .andExpect(status().isBadRequest())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.detail").value("Only userId 0 is supported."));
 
         verify(synchronisePermissionsService, never()).synchronise(any(UserEntity.class));
     }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/rolemapping/UserServiceNormalModeIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/rolemapping/UserServiceNormalModeIntegrationTest.java
@@ -3,6 +3,8 @@ package uk.gov.hmcts.reform.opal.rolemapping;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -33,11 +35,11 @@ class UserServiceNormalModeIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("AC2: should load APIs normally when AutomatedTask is absent")
     void shouldLoadApiNormally() throws Exception {
-        long userIdWithPermissions = 500000000L;
 
-        MockHttpServletRequestBuilder builder = get(URL_BASE + "/" + userIdWithPermissions + "/state")
-            .principal(createJwtPrincipal());
+        Authentication auth = createJwtPrincipal("k9LpT2xVqR8m","opal-test@HMCTS.NET", "Pablo");
+        SecurityContextHolder.getContext().setAuthentication(auth);
 
+        MockHttpServletRequestBuilder builder = get(URL_BASE + "/0/state");
         mockMvc.perform(builder)
             .andExpect(status().isOk())
             .andExpect(content().contentType(APPLICATION_JSON))
@@ -45,16 +47,15 @@ class UserServiceNormalModeIntegrationTest extends AbstractIntegrationTest {
             .andExpect(jsonPath("$.username").value("opal-test@HMCTS.NET"));
     }
 
-    private JwtAuthenticationToken createJwtPrincipal() {
+    private JwtAuthenticationToken createJwtPrincipal(String sub, String preferred, String name) {
         Jwt jwt = new Jwt(
             "mock-token-value",
             Instant.now(),
             Instant.now().plusSeconds(3600),
             Map.of("alg", "none"),
-            Map.of(
-                "sub", "jjqwGAERGW43",
-                "preferred_username", "opal-test@HMCTS.NET",
-                "name", "Pablo"
+            Map.of("sub", sub,
+                   "preferred_username", preferred,
+                   "name", name
             )
         );
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/service/synchronise/SynchronisePermissionsServiceIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/service/synchronise/SynchronisePermissionsServiceIntegrationTest.java
@@ -63,7 +63,7 @@ class SynchronisePermissionsServiceIntegrationTest extends AbstractLegacyWireMoc
 
         legacyWireMockXmlStubHelper.registerSystemUserLookupStub(List.of("123"));
         legacyWireMockXmlStubHelper.registerBusinessUnitUserLookupStub(legacyBusinessUnitUsersForTargetUser());
-        TestHelperUtil.setAuthenticatedUser(user.getTokenSubject());
+        TestHelperUtil.setAuthenticatedUser(user);
         String cacheKey = ROLE_MAPPING_USER_PREFIX + user.getTokenSubject();
         redisTemplate.opsForValue().set(
             cacheKey,

--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/service/synchronise/TestHelperUtil.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/service/synchronise/TestHelperUtil.java
@@ -40,6 +40,21 @@ public final class TestHelperUtil {
         SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(jwt));
     }
 
+    public static void setAuthenticatedUser(UserEntity user) {
+        Jwt jwt = new Jwt(
+            "integration-test-token",
+            Instant.now(),
+            Instant.now().plusSeconds(3600),
+            Map.of("alg", "none"),
+            Map.of(
+                "sub", user.getTokenSubject(),
+                "preferred_username", user.getUsername(),
+                "name", user.getTokenName()
+            )
+        );
+        SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(jwt));
+    }
+
     public static UserEntity buildUser(long userId, String tokenSubject) {
         return UserEntity.builder()
             .userId(userId)

--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/service/synchronise/TestHelperUtil.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/service/synchronise/TestHelperUtil.java
@@ -29,17 +29,6 @@ public final class TestHelperUtil {
         return legacyBusinessUnitUser(businessUnitUserId, Short.toString(businessUnitId));
     }
 
-    public static void setAuthenticatedUser(String tokenSubject) {
-        Jwt jwt = new Jwt(
-            "integration-test-token",
-            Instant.now(),
-            Instant.now().plusSeconds(3600),
-            Map.of("alg", "none"),
-            Map.of("sub", tokenSubject)
-        );
-        SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(jwt));
-    }
-
     public static void setAuthenticatedUser(UserEntity user) {
         Jwt jwt = new Jwt(
             "integration-test-token",

--- a/src/main/java/uk/gov/hmcts/reform/opal/controllers/UserPermissionsV2Controller.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/controllers/UserPermissionsV2Controller.java
@@ -2,7 +2,9 @@ package uk.gov.hmcts.reform.opal.controllers;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -20,6 +22,7 @@ import static uk.gov.hmcts.reform.opal.util.HttpUtil.buildResponse;
 public class UserPermissionsV2Controller {
 
     private static final String X_NEW_LOGIN = "X-New-Login";
+    private static final Long CURRENT_USER_ID = 0L;
     private final UserPermissionsService userPermissionsService;
 
     @GetMapping("/{userId}/state")
@@ -28,6 +31,10 @@ public class UserPermissionsV2Controller {
         @RequestHeader(value = X_NEW_LOGIN, required = false) Boolean newLogin) {
 
         log.debug(":GET:getUserStateV2: userId: {}, new login: {}", userId, newLogin);
-        return buildResponse(userPermissionsService.getUserStateV2(userId, newLogin));
+        if (!CURRENT_USER_ID.equals(userId)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Only userId 0 is supported.");
+        }
+        boolean isNewLogin = Boolean.TRUE.equals(newLogin);
+        return buildResponse(userPermissionsService.getUserStateV2(isNewLogin));
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/opal/service/UserPermissionsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/service/UserPermissionsService.java
@@ -101,16 +101,18 @@ public class UserPermissionsService {
     }
 
     @Transactional
-    public UserStateV2Dto getUserStateV2(Long userId, Boolean newLogin) {
-        log.debug(":getUserState: userId: {}", userId);
+    public UserStateV2Dto getUserStateV2(boolean newLogin) {
+        log.debug(":getUserState");
 
-        UserEntity user;
-        if (userId == 0) {
-            user = getAndValidateAuthenticatedUser();
-        } else {
-            user = userRepository.findById(userId)
-                .orElseThrow(() -> new EntityNotFoundException("User not found with id: " + userId));
-        }
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Jwt jwt = getJwtToken(authentication);
+        String subject = extractSubject(jwt);
+
+        UserEntity user = userRepository.findByTokenSubject(subject)
+            .orElseThrow(() -> new EntityNotFoundException("User not found with subject: " + subject));
+        Long userId = user.getUserId();
+
+        validateAuthenticatedUser(user, jwt);
 
         if (appModeConfiguration.getAppMode().equalsIgnoreCase("legacy")) {
             synchronisePermissionsService.synchronise(user);
@@ -120,16 +122,11 @@ public class UserPermissionsService {
 
         // NB. When legacy refresh gets deleted we will need to update the first fetch to include all roles
         // and remove this second fetch
-        user = userRepository.findIdWithPermissions(user.getUserId())
+        user = userRepository.findIdWithPermissions(userId)
             .orElseThrow(() -> new EntityNotFoundException("User not found with id: " + userId));
 
-        if (Optional.ofNullable(newLogin).orElse(false)) {
-            Long authenticationEventUserId = user.getUserId();
-            if (userId != 0) {
-                Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-                authenticationEventUserId = getUserId(authentication);
-            }
-            logUserAuthenticationEvent(authenticationEventUserId);
+        if (newLogin) {
+            logUserAuthenticationEvent(userId);
             updateLastLogin(user);
         }
 
@@ -138,19 +135,11 @@ public class UserPermissionsService {
         return dto;
     }
 
-    private UserEntity getAndValidateAuthenticatedUser() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Jwt jwt = getJwtToken(authentication);
-        String subject = extractSubject(jwt);
-
-        UserEntity user = userRepository.findByTokenSubject(subject)
-            .orElseThrow(() -> new EntityNotFoundException("User not found with subject: " + subject));
-
+    private void validateAuthenticatedUser(UserEntity user, Jwt jwt) {
         String username = extractClaim(jwt, PREFERRED_USERNAME_CLAIM);
         compare(username, user.getUsername(), user.getUserId(), "Preferred Username mismatch:", user);
         String name = extractClaim(jwt, NAME_CLAIM);
         compare(name, user.getTokenName(), user.getUserId(), "Name mismatch:", user);
-        return user;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/uk/gov/hmcts/reform/opal/service/UserPermissionsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/service/UserPermissionsService.java
@@ -9,7 +9,6 @@ import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -50,22 +49,6 @@ import uk.gov.hmcts.reform.opal.repository.UserEntitlementRepository;
 import uk.gov.hmcts.reform.opal.repository.UserRepository;
 import uk.gov.hmcts.reform.opal.service.opal.UserService;
 import uk.gov.hmcts.reform.opal.service.synchronise.SynchronisePermissionsService;
-
-import java.time.Clock;
-import java.time.LocalDateTime;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
-import static uk.gov.hmcts.opal.common.dto.ToJsonString.objectToPrettyJson;
-import static uk.gov.hmcts.opal.common.logging.LogUtil.getRequestTimestamp;
-import static uk.gov.hmcts.reform.opal.util.VersionUtils.verifyIfMatch;
-
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/uk/gov/hmcts/reform/opal/service/UserPermissionsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/service/UserPermissionsService.java
@@ -104,15 +104,8 @@ public class UserPermissionsService {
     public UserStateV2Dto getUserStateV2(boolean newLogin) {
         log.debug(":getUserState");
 
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Jwt jwt = getJwtToken(authentication);
-        String subject = extractSubject(jwt);
-
-        UserEntity user = userRepository.findByTokenSubject(subject)
-            .orElseThrow(() -> new EntityNotFoundException("User not found with subject: " + subject));
+        UserEntity user = getUserFromAuthentication();
         Long userId = user.getUserId();
-
-        validateAuthenticatedUser(user, jwt);
 
         if (appModeConfiguration.getAppMode().equalsIgnoreCase("legacy")) {
             synchronisePermissionsService.synchronise(user);
@@ -133,6 +126,16 @@ public class UserPermissionsService {
         UserStateV2Dto dto = userStateMapper.toUserStateV2Dto(user, clock);
         cacheUserState(dto, user);
         return dto;
+    }
+
+    private UserEntity getUserFromAuthentication() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Jwt jwt = getJwtToken(authentication);
+        String subject = extractSubject(jwt);
+        UserEntity user = userRepository.findByTokenSubject(subject)
+            .orElseThrow(() -> new EntityNotFoundException("User not found with subject: " + subject));
+        validateAuthenticatedUser(user, jwt);
+        return user;
     }
 
     private void validateAuthenticatedUser(UserEntity user, Jwt jwt) {

--- a/src/main/resources/openapi/userState.yaml
+++ b/src/main/resources/openapi/userState.yaml
@@ -21,6 +21,8 @@ paths:
           schema:
             type: integer
             format: int64
+            minimum: 0
+            maximum: 0
         - name: X-New-Login
           in: header
           required: true

--- a/src/main/resources/openapi/userState.yaml
+++ b/src/main/resources/openapi/userState.yaml
@@ -55,8 +55,8 @@ paths:
       operationId: getUserStateV2
       summary: Get User State (v2)
       description: >
-        Returns the user state for a given user ID (v2).
-        If the ID is `0`, returns the authenticated user's state.
+        Returns the authenticated user's state (v2).
+        The path ID must be `0`; any non-zero value is rejected.
         V2 payload includes `domains`, optional `fines`, and `business_unit_users`.
       tags:
         - Users State
@@ -64,7 +64,7 @@ paths:
         - name: id
           in: path
           required: true
-          description: User identifier. Use `0` to return the authenticated user.
+          description: User identifier. Must be `0` for the authenticated user.
           schema:
             type: integer
             format: int64
@@ -85,7 +85,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/UserStateResponseV2'
         '400':
-          description: Invalid request
+          description: Invalid request (for example, non-zero user id)
           content:
             application/json+problem:
               schema:

--- a/src/test/java/uk/gov/hmcts/reform/opal/controllers/UserPermissionsV2ControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/opal/controllers/UserPermissionsV2ControllerTest.java
@@ -9,10 +9,14 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.server.ResponseStatusException;
 import uk.gov.hmcts.opal.common.user.authorisation.client.dto.UserStateV2Dto;
 import uk.gov.hmcts.reform.opal.service.UserPermissionsService;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @Slf4j(topic = "opal.UserPermissionsV2ControllerTest")
@@ -29,10 +33,10 @@ class UserPermissionsV2ControllerTest {
     @DisplayName("controller.getUserStateV2 should return DTO from the service")
     void testGetUserStateV2() {
         // Arrange
-        Long userId = 123L;
+        Long userId = 0L;
         Boolean newLogin = true;
         UserStateV2Dto dto = new UserStateV2Dto();
-        when(userPermissionsService.getUserStateV2(userId, newLogin))
+        when(userPermissionsService.getUserStateV2(newLogin))
             .thenReturn(dto);
 
         // Act
@@ -41,5 +45,39 @@ class UserPermissionsV2ControllerTest {
         // Assert
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isEqualTo(dto);
+    }
+
+    @Test
+    @DisplayName("controller.getUserStateV2 should treat null X-New-Login as false")
+    void testGetUserStateV2TreatsNullNewLoginAsFalse() {
+        // Arrange
+        Long userId = 0L;
+        Boolean newLogin = null;
+        UserStateV2Dto dto = new UserStateV2Dto();
+        when(userPermissionsService.getUserStateV2(false))
+            .thenReturn(dto);
+
+        // Act
+        ResponseEntity<UserStateV2Dto> response = controller.getUserStateV2(userId, newLogin);
+
+        // Assert
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(dto);
+        verify(userPermissionsService).getUserStateV2(false);
+    }
+
+    @Test
+    @DisplayName("controller.getUserStateV2 should reject non-zero user id with bad request")
+    void testGetUserStateV2RejectsNonZeroUserId() {
+        // Arrange
+        Long userId = 123L;
+        Boolean newLogin = true;
+
+        // Act / Assert
+        assertThatThrownBy(() -> controller.getUserStateV2(userId, newLogin))
+            .isInstanceOf(ResponseStatusException.class)
+            .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode())
+                .isEqualTo(HttpStatus.BAD_REQUEST));
+        verifyNoInteractions(userPermissionsService);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/opal/service/UserPermissionsServiceV2Test.java
+++ b/src/test/java/uk/gov/hmcts/reform/opal/service/UserPermissionsServiceV2Test.java
@@ -45,7 +45,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -140,6 +143,18 @@ class UserPermissionsServiceV2Test {
         assertThat(userEntity.getLastLoginDate())
             .isEqualTo(LocalDateTime.ofInstant(fixedInstant, fixedZone));
         verify(userRepository).saveAndFlush(userEntity);
+        verify(securityEventLoggingService).logEvent(
+            eq("User Authentication"),
+            eq("Success"),
+            isNull(),
+            eq("Authentication"),
+            notNull(),
+            argThat(data ->
+                        data != null
+                            && data.size() == 1
+                            && Long.valueOf(USER_ID).equals(data.get("UserIdentifier"))
+            )
+        );
         assertDtoWasCachedForSubject(TOKEN_SUBJECT);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/opal/service/UserPermissionsServiceV2Test.java
+++ b/src/test/java/uk/gov/hmcts/reform/opal/service/UserPermissionsServiceV2Test.java
@@ -19,16 +19,12 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.web.server.ResponseStatusException;
 import uk.gov.hmcts.opal.common.logging.SecurityEventLoggingService;
-import uk.gov.hmcts.opal.common.user.authentication.service.AccessTokenService;
-import uk.gov.hmcts.opal.common.user.authentication.service.TokenValidator;
 import uk.gov.hmcts.opal.common.user.authorisation.client.dto.UserStateV2Dto;
 import uk.gov.hmcts.reform.opal.config.properties.AppModeConfiguration;
 import uk.gov.hmcts.reform.opal.config.properties.CacheConfiguration;
 import uk.gov.hmcts.reform.opal.entity.UserEntity;
-import uk.gov.hmcts.reform.opal.mappers.UserMapper;
+import uk.gov.hmcts.reform.opal.exception.ResourceConflictException;
 import uk.gov.hmcts.reform.opal.mappers.UserStateMapper;
-import uk.gov.hmcts.reform.opal.repository.BusinessUnitUserRepository;
-import uk.gov.hmcts.reform.opal.repository.UserEntitlementRepository;
 import uk.gov.hmcts.reform.opal.repository.UserRepository;
 import uk.gov.hmcts.reform.opal.service.opal.UserService;
 import uk.gov.hmcts.reform.opal.service.synchronise.SynchronisePermissionsService;
@@ -37,6 +33,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -47,10 +44,8 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -63,21 +58,13 @@ import static org.mockito.Mockito.when;
 class UserPermissionsServiceV2Test {
 
     private static final long USER_ID = 42L;
-    private static final long AUTHENTICATED_USER_ID = 84L;
     private static final long CACHE_TIMEOUT_MINUTES = 30L;
     private static final String TOKEN_PREFERRED_USERNAME = "opal-user@hmcts.net";
     private static final String TOKEN_NAME = "John Smith";
     private static final String TOKEN_SUBJECT = "hcv732JFVWhf3Fd";
-    private static final String AUTHENTICATED_TOKEN_SUBJECT = "auth-subject-84";
 
     @Mock
     SecurityContext securityContext;
-
-    @Mock
-    private UserEntitlementRepository userEntitlementRepository;
-
-    @Mock
-    private BusinessUnitUserRepository businessUnitUserRepository;
 
     @Mock
     private UserRepository userRepository;
@@ -86,19 +73,7 @@ class UserPermissionsServiceV2Test {
     private UserStateMapper userStateMapper;
 
     @Mock
-    private UserMapper userMapper;
-
-    @Mock
-    private AccessTokenService tokenService;
-
-    @Mock
-    private TokenValidator tokenValidator;
-
-    @Mock
     private SecurityEventLoggingService securityEventLoggingService;
-
-    @Mock
-    private Jwt jwt;
 
     @Mock
     private Clock clock;
@@ -152,20 +127,13 @@ class UserPermissionsServiceV2Test {
         when(clock.instant()).thenReturn(fixedInstant);
         when(clock.getZone()).thenReturn(fixedZone);
 
-        JwtAuthenticationToken authentication = mock(JwtAuthenticationToken.class);
-        when(authentication.getToken()).thenReturn(jwt);
-        when(securityContext.getAuthentication()).thenReturn(authentication);
-        SecurityContextHolder.setContext(securityContext);
-
-        when(jwt.getSubject()).thenReturn(TOKEN_SUBJECT);
+        setJwtAuthentication(TOKEN_SUBJECT, TOKEN_PREFERRED_USERNAME, TOKEN_NAME);
         when(userRepository.findByTokenSubject(TOKEN_SUBJECT)).thenReturn(Optional.of(userEntity));
         when(userRepository.findIdWithPermissions(USER_ID)).thenReturn(Optional.of(userEntity));
-        when(jwt.getClaimAsString("preferred_username")).thenReturn(TOKEN_PREFERRED_USERNAME);
-        when(jwt.getClaimAsString("name")).thenReturn(TOKEN_NAME);
         when(userStateMapper.toUserStateV2Dto(userEntity, clock)).thenReturn(dto);
 
         // Act
-        UserStateV2Dto result = service.getUserStateV2(0L, true);
+        UserStateV2Dto result = service.getUserStateV2(true);
 
         // Assert
         assertThat(result).isEqualTo(dto);
@@ -179,20 +147,13 @@ class UserPermissionsServiceV2Test {
     void getUserStateV2_NotNewLogin() {
 
         // Arrange
-        JwtAuthenticationToken authentication = mock(JwtAuthenticationToken.class);
-        when(authentication.getToken()).thenReturn(jwt);
-        when(securityContext.getAuthentication()).thenReturn(authentication);
-        SecurityContextHolder.setContext(securityContext);
-
-        when(jwt.getSubject()).thenReturn(TOKEN_SUBJECT);
+        setJwtAuthentication(TOKEN_SUBJECT, TOKEN_PREFERRED_USERNAME, TOKEN_NAME);
         when(userRepository.findByTokenSubject(TOKEN_SUBJECT)).thenReturn(Optional.of(userEntity));
         when(userRepository.findIdWithPermissions(USER_ID)).thenReturn(Optional.of(userEntity));
-        when(jwt.getClaimAsString("preferred_username")).thenReturn(TOKEN_PREFERRED_USERNAME);
-        when(jwt.getClaimAsString("name")).thenReturn(TOKEN_NAME);
         when(userStateMapper.toUserStateV2Dto(userEntity, clock)).thenReturn(dto);
 
         // Act
-        UserStateV2Dto result = service.getUserStateV2(0L, false);
+        UserStateV2Dto result = service.getUserStateV2(false);
 
         // Assert
         assertThat(result).isEqualTo(dto);
@@ -204,16 +165,9 @@ class UserPermissionsServiceV2Test {
     void getUserStateV2_whenRedisCachingFails_doesNotThrowAndReturnsDto() {
 
         // arrange
-        JwtAuthenticationToken authentication = mock(JwtAuthenticationToken.class);
-        when(authentication.getToken()).thenReturn(jwt);
-        when(securityContext.getAuthentication()).thenReturn(authentication);
-        SecurityContextHolder.setContext(securityContext);
-
-        when(jwt.getSubject()).thenReturn(TOKEN_SUBJECT);
+        setJwtAuthentication(TOKEN_SUBJECT, TOKEN_PREFERRED_USERNAME, TOKEN_NAME);
         when(userRepository.findByTokenSubject(TOKEN_SUBJECT)).thenReturn(Optional.of(userEntity));
         when(userRepository.findIdWithPermissions(USER_ID)).thenReturn(Optional.of(userEntity));
-        when(jwt.getClaimAsString("preferred_username")).thenReturn(TOKEN_PREFERRED_USERNAME);
-        when(jwt.getClaimAsString("name")).thenReturn(TOKEN_NAME);
         when(userStateMapper.toUserStateV2Dto(userEntity, clock)).thenReturn(dto);
 
         doThrow(new DataAccessResourceFailureException("Redis unavailable"))
@@ -221,27 +175,7 @@ class UserPermissionsServiceV2Test {
             .set(eq("USER_STATE_" + TOKEN_SUBJECT), anyString(), eq(CACHE_TIMEOUT_MINUTES), eq(TimeUnit.MINUTES));
 
         // act & assert
-        UserStateV2Dto result = assertDoesNotThrow(() -> service.getUserStateV2(0L, false));
-
-        assertThat(result).isEqualTo(dto);
-        assertThat(result.getCacheName()).isEqualTo("USER_STATE_" + TOKEN_SUBJECT);
-        verifyNoInteractions(securityEventLoggingService);
-    }
-
-    @Test
-    void getUserStateV2IdMethod_whenRedisCachingFails_doesNotThrowAndReturnsDto() {
-
-        // arrange
-        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(userEntity));
-        when(userRepository.findIdWithPermissions(USER_ID)).thenReturn(Optional.of(userEntity));
-        when(userStateMapper.toUserStateV2Dto(userEntity, clock)).thenReturn(dto);
-
-        doThrow(new DataAccessResourceFailureException("Redis unavailable"))
-            .when(valueOperations)
-            .set(eq("USER_STATE_" + TOKEN_SUBJECT), anyString(), eq(CACHE_TIMEOUT_MINUTES), eq(TimeUnit.MINUTES));
-
-        // act & assert
-        UserStateV2Dto result = assertDoesNotThrow(() -> service.getUserStateV2(USER_ID, false));
+        UserStateV2Dto result = assertDoesNotThrow(() -> service.getUserStateV2(false));
 
         assertThat(result).isEqualTo(dto);
         assertThat(result.getCacheName()).isEqualTo("USER_STATE_" + TOKEN_SUBJECT);
@@ -252,13 +186,14 @@ class UserPermissionsServiceV2Test {
     void getUserStateV2_whenLegacySynchronisationSucceeds_callsSynchroniseAndRefreshUser() {
 
         // Arrange
+        setJwtAuthentication(TOKEN_SUBJECT, TOKEN_PREFERRED_USERNAME, TOKEN_NAME);
         when(appModeConfiguration.getAppMode()).thenReturn("legacy");
-        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(userEntity));
         when(userRepository.findIdWithPermissions(USER_ID)).thenReturn(Optional.of(userEntity));
         when(userStateMapper.toUserStateV2Dto(userEntity, clock)).thenReturn(dto);
+        when(userRepository.findByTokenSubject(TOKEN_SUBJECT)).thenReturn(Optional.of(userEntity));
 
         // Act
-        UserStateV2Dto result = service.getUserStateV2(USER_ID, false);
+        UserStateV2Dto result = service.getUserStateV2(false);
 
         // Assert
         assertThat(result).isEqualTo(dto);
@@ -271,15 +206,16 @@ class UserPermissionsServiceV2Test {
     void getUserStateV2_whenLegacySynchronisationThrowsRuntime_propagatesRuntimeException() {
 
         // Arrange
+        setJwtAuthentication(TOKEN_SUBJECT, TOKEN_PREFERRED_USERNAME, TOKEN_NAME);
         RuntimeException runtimeException = new RuntimeException("sync failed");
         when(appModeConfiguration.getAppMode()).thenReturn("legacy");
-        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(userEntity));
         doThrow(runtimeException).when(synchronisePermissionsService).synchronise(userEntity);
+        when(userRepository.findByTokenSubject(TOKEN_SUBJECT)).thenReturn(Optional.of(userEntity));
 
         // Act
         RuntimeException thrown = assertThrows(
             RuntimeException.class,
-            () -> service.getUserStateV2(USER_ID, false)
+            () -> service.getUserStateV2(false)
         );
 
         // Assert
@@ -291,13 +227,14 @@ class UserPermissionsServiceV2Test {
     void getUserStateV2_whenAppModeIsOpal_doesNotCallLegacySynchronisationServices() {
 
         // Arrange
+        setJwtAuthentication(TOKEN_SUBJECT, TOKEN_PREFERRED_USERNAME, TOKEN_NAME);
         when(appModeConfiguration.getAppMode()).thenReturn("opal");
-        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(userEntity));
         when(userRepository.findIdWithPermissions(USER_ID)).thenReturn(Optional.of(userEntity));
         when(userStateMapper.toUserStateV2Dto(userEntity, clock)).thenReturn(dto);
+        when(userRepository.findByTokenSubject(TOKEN_SUBJECT)).thenReturn(Optional.of(userEntity));
 
         // Act
-        UserStateV2Dto result = service.getUserStateV2(USER_ID, false);
+        UserStateV2Dto result = service.getUserStateV2(false);
 
         // Assert
         assertThat(result).isEqualTo(dto);
@@ -316,7 +253,7 @@ class UserPermissionsServiceV2Test {
         // Act & Assert
         ResponseStatusException ex = assertThrows(
             ResponseStatusException.class,
-            () -> service.getUserStateV2(0L, true)
+            () -> service.getUserStateV2(true)
         );
         assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
         assertEquals("401 UNAUTHORIZED \"Authentication Token not of type Jwt.\"", ex.getMessage());
@@ -326,16 +263,12 @@ class UserPermissionsServiceV2Test {
     void getUserStateV2_SubjectClaimMissing() {
 
         // Arrange
-        JwtAuthenticationToken authentication = mock(JwtAuthenticationToken.class);
-        when(authentication.getToken()).thenReturn(jwt);
-        when(jwt.getSubject()).thenReturn(null);
-        when(securityContext.getAuthentication()).thenReturn(authentication);
-        SecurityContextHolder.setContext(securityContext);
+        setJwtAuthentication(null, TOKEN_PREFERRED_USERNAME, TOKEN_NAME);
 
         // Act & Assert
         ResponseStatusException ex = assertThrows(
             ResponseStatusException.class,
-            () -> service.getUserStateV2(0L, true)
+            () -> service.getUserStateV2(true)
         );
         assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
         assertEquals("401 UNAUTHORIZED \"Subject not found.\"", ex.getMessage());
@@ -345,18 +278,13 @@ class UserPermissionsServiceV2Test {
     void getUserStateV2_WhenAuthenticatedUserNotFound_ThrowsEntityNotFoundException() {
 
         // Arrange
-        JwtAuthenticationToken authentication = mock(JwtAuthenticationToken.class);
-        when(authentication.getToken()).thenReturn(jwt);
-        when(securityContext.getAuthentication()).thenReturn(authentication);
-        SecurityContextHolder.setContext(securityContext);
-
-        when(jwt.getSubject()).thenReturn(TOKEN_SUBJECT);
+        setJwtAuthentication(TOKEN_SUBJECT, TOKEN_PREFERRED_USERNAME, TOKEN_NAME);
         when(userRepository.findByTokenSubject(TOKEN_SUBJECT)).thenReturn(Optional.empty());
 
         // Act
         EntityNotFoundException ex = assertThrows(
             EntityNotFoundException.class,
-            () -> service.getUserStateV2(0L, false)
+            () -> service.getUserStateV2(false)
         );
 
         // Assert
@@ -369,17 +297,19 @@ class UserPermissionsServiceV2Test {
     void getUserStateV2_WhenRequestedUserNotFound_ThrowsEntityNotFoundException() {
 
         // Arrange
-        when(userRepository.findById(USER_ID)).thenReturn(Optional.empty());
+        setJwtAuthentication(TOKEN_SUBJECT, TOKEN_PREFERRED_USERNAME, TOKEN_NAME);
+        when(userRepository.findByTokenSubject(TOKEN_SUBJECT)).thenReturn(Optional.of(userEntity));
+        when(userRepository.findIdWithPermissions(USER_ID)).thenReturn(Optional.empty());
 
         // Act
         EntityNotFoundException ex = assertThrows(
             EntityNotFoundException.class,
-            () -> service.getUserStateV2(USER_ID, false)
+            () -> service.getUserStateV2(false)
         );
 
         // Assert
         assertThat(ex).hasMessage("User not found with id: " + USER_ID);
-        verify(userRepository, never()).findIdWithPermissions(anyLong());
+        verify(userRepository).findIdWithPermissions(USER_ID);
         verifyNoInteractions(userStateMapper);
     }
 
@@ -387,160 +317,77 @@ class UserPermissionsServiceV2Test {
     void getUserStateV2_PreferredUsernameClaimMissing() {
 
         // Arrange
-        JwtAuthenticationToken authentication = mock(JwtAuthenticationToken.class);
-        when(authentication.getToken()).thenReturn(jwt);
-        when(securityContext.getAuthentication()).thenReturn(authentication);
-        SecurityContextHolder.setContext(securityContext);
-
-        when(jwt.getSubject()).thenReturn(TOKEN_SUBJECT);
+        setJwtAuthentication(TOKEN_SUBJECT, null, TOKEN_NAME);
         when(userRepository.findByTokenSubject(TOKEN_SUBJECT)).thenReturn(Optional.of(userEntity));
-        when(jwt.getClaimAsString("preferred_username")).thenReturn(null);
 
         // Act & Assert
         ResponseStatusException ex = assertThrows(
             ResponseStatusException.class,
-            () -> service.getUserStateV2(0L, true)
+            () -> service.getUserStateV2(true)
         );
         assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
         assertEquals("401 UNAUTHORIZED \"Claim not found: preferred_username\"", ex.getMessage());
     }
 
     @Test
-    void getUserStateV2IdMethod_NewLoginWhenIdIsNonZero() {
+    void getUserStateV2_NameClaimMissing() {
 
         // Arrange
-        Instant fixedInstant = Instant.parse("2026-04-14T10:15:30Z");
-        ZoneId fixedZone = ZoneId.of("UTC");
-        when(clock.instant()).thenReturn(fixedInstant);
-        when(clock.getZone()).thenReturn(fixedZone);
-        setAuthenticatedCaller(AUTHENTICATED_USER_ID, AUTHENTICATED_TOKEN_SUBJECT);
+        setJwtAuthentication(TOKEN_SUBJECT, TOKEN_PREFERRED_USERNAME, null);
+        when(userRepository.findByTokenSubject(TOKEN_SUBJECT)).thenReturn(Optional.of(userEntity));
 
-        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(userEntity));
-        when(userRepository.findIdWithPermissions(USER_ID)).thenReturn(Optional.of(userEntity));
-        when(userStateMapper.toUserStateV2Dto(userEntity, clock)).thenReturn(dto);
-
-        // Act
-        UserStateV2Dto result = service.getUserStateV2(USER_ID, true);
-
-        // Assert
-        assertThat(result).isEqualTo(dto);
-        assertThat(userEntity.getLastLoginDate())
-            .isEqualTo(LocalDateTime.ofInstant(fixedInstant, fixedZone));
-        verify(userRepository).saveAndFlush(userEntity);
-        @SuppressWarnings("unchecked")
-        ArgumentCaptor<Map<String, Object>> eventDataCaptor = ArgumentCaptor.forClass(Map.class);
-        verify(securityEventLoggingService).logEvent(
-            eq("User Authentication"),
-            eq("Success"),
-            isNull(),
-            eq("Authentication"),
-            any(),
-            eventDataCaptor.capture()
+        // Act & Assert
+        ResponseStatusException ex = assertThrows(
+            ResponseStatusException.class,
+            () -> service.getUserStateV2(true)
         );
-        assertThat(eventDataCaptor.getValue()).containsEntry("UserIdentifier", AUTHENTICATED_USER_ID);
-        assertDtoWasCachedForSubject(TOKEN_SUBJECT);
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertEquals("401 UNAUTHORIZED \"Claim not found: name\"", ex.getMessage());
     }
 
     @Test
-    void getUserStateV2IdMethod_NonNewLoginWhenIdIsNonZero() {
+    void getUserStateV2_PreferredUsernameMismatch_ThrowsResourceConflictException() {
 
         // Arrange
-        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(userEntity));
-        when(userRepository.findIdWithPermissions(USER_ID)).thenReturn(Optional.of(userEntity));
-        when(userStateMapper.toUserStateV2Dto(userEntity, clock)).thenReturn(dto);
+        setJwtAuthentication(TOKEN_SUBJECT, "different-user@hmcts.net", TOKEN_NAME);
+        when(userRepository.findByTokenSubject(TOKEN_SUBJECT)).thenReturn(Optional.of(userEntity));
 
         // Act
-        UserStateV2Dto result = service.getUserStateV2(USER_ID, false);
+        ResourceConflictException ex = assertThrows(
+            ResourceConflictException.class,
+            () -> service.getUserStateV2(false)
+        );
 
         // Assert
-        assertThat(result).isEqualTo(dto);
-        verifyNoInteractions(securityEventLoggingService);
-        assertDtoWasCachedForSubject(TOKEN_SUBJECT);
+        assertEquals("User", ex.getResourceType());
+        assertEquals(String.valueOf(USER_ID), ex.getResourceId());
+        assertThat(ex.getConflictReason()).startsWith("Preferred Username mismatch:");
     }
 
-    @Test
-    void getUserStateV2IdMethod_WhenIdIsZero() {
-
-        // Arrange
-        Instant fixedInstant = Instant.parse("2026-04-14T10:15:30Z");
-        ZoneId fixedZone = ZoneId.of("UTC");
-        when(clock.instant()).thenReturn(fixedInstant);
-        when(clock.getZone()).thenReturn(fixedZone);
-
-        JwtAuthenticationToken authentication = mock(JwtAuthenticationToken.class);
-        when(authentication.getToken()).thenReturn(jwt);
+    private void setJwtAuthentication(String subject, String preferredUsername, String name) {
+        JwtAuthenticationToken authentication = new JwtAuthenticationToken(createJwt(subject, preferredUsername, name));
         when(securityContext.getAuthentication()).thenReturn(authentication);
         SecurityContextHolder.setContext(securityContext);
-
-        when(jwt.getSubject()).thenReturn(TOKEN_SUBJECT);
-        when(userRepository.findByTokenSubject(TOKEN_SUBJECT)).thenReturn(Optional.of(userEntity));
-        when(userRepository.findIdWithPermissions(USER_ID)).thenReturn(Optional.of(userEntity));
-        when(jwt.getClaimAsString("preferred_username")).thenReturn(TOKEN_PREFERRED_USERNAME);
-        when(jwt.getClaimAsString("name")).thenReturn(TOKEN_NAME);
-        when(userStateMapper.toUserStateV2Dto(userEntity, clock)).thenReturn(dto);
-
-        // Act
-        UserStateV2Dto result = service.getUserStateV2(0L, true);
-
-        // Assert
-        assertThat(result).isEqualTo(dto);
-        verify(userRepository).saveAndFlush(userEntity);
-        assertDtoWasCachedForSubject(TOKEN_SUBJECT);
     }
 
-    @Test
-    void getUserStateV2_NewLogin_UpdatesLastLogin() {
-        // Arrange
-        Instant fixedInstant = Instant.parse("2026-04-14T10:15:30Z");
-        ZoneId fixedZone = ZoneId.of("UTC");
-        when(clock.instant()).thenReturn(fixedInstant);
-        when(clock.getZone()).thenReturn(fixedZone);
-
-        JwtAuthenticationToken authentication = mock(JwtAuthenticationToken.class);
-        when(authentication.getToken()).thenReturn(jwt);
-        when(securityContext.getAuthentication()).thenReturn(authentication);
-        SecurityContextHolder.setContext(securityContext);
-
-        when(jwt.getSubject()).thenReturn(TOKEN_SUBJECT);
-        when(userRepository.findByTokenSubject(TOKEN_SUBJECT)).thenReturn(Optional.of(userEntity));
-        when(userRepository.findIdWithPermissions(USER_ID)).thenReturn(Optional.of(userEntity));
-        when(jwt.getClaimAsString("preferred_username")).thenReturn(TOKEN_PREFERRED_USERNAME);
-        when(jwt.getClaimAsString("name")).thenReturn(TOKEN_NAME);
-        when(userStateMapper.toUserStateV2Dto(userEntity, clock)).thenReturn(dto);
-
-        // Act
-        UserStateV2Dto result = service.getUserStateV2(0L, true);
-
-        // Assert
-        assertThat(result).isEqualTo(dto);
-        assertThat(userEntity.getLastLoginDate())
-            .isEqualTo(LocalDateTime.ofInstant(fixedInstant, fixedZone));
-        verify(userRepository).saveAndFlush(userEntity);
-        assertDtoWasCachedForSubject(TOKEN_SUBJECT);
-    }
-
-    @Test
-    void getUserStateV2IdMethod_NewLogin_UpdatesLastLogin() {
-        // Arrange
-        Instant fixedInstant = Instant.parse("2026-04-14T10:15:30Z");
-        ZoneId fixedZone = ZoneId.of("UTC");
-        when(clock.instant()).thenReturn(fixedInstant);
-        when(clock.getZone()).thenReturn(fixedZone);
-        setAuthenticatedCaller(AUTHENTICATED_USER_ID, AUTHENTICATED_TOKEN_SUBJECT);
-
-        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(userEntity));
-        when(userRepository.findIdWithPermissions(USER_ID)).thenReturn(Optional.of(userEntity));
-        when(userStateMapper.toUserStateV2Dto(userEntity, clock)).thenReturn(dto);
-
-        // Act
-        UserStateV2Dto result = service.getUserStateV2(USER_ID, true);
-
-        // Assert
-        assertThat(result).isEqualTo(dto);
-        assertThat(userEntity.getLastLoginDate())
-            .isEqualTo(LocalDateTime.ofInstant(fixedInstant, fixedZone));
-        verify(userRepository).saveAndFlush(userEntity);
-        assertDtoWasCachedForSubject(TOKEN_SUBJECT);
+    private Jwt createJwt(String subject, String preferredUsername, String name) {
+        Map<String, Object> claims = new HashMap<>();
+        if (subject != null) {
+            claims.put("sub", subject);
+        }
+        if (preferredUsername != null) {
+            claims.put("preferred_username", preferredUsername);
+        }
+        if (name != null) {
+            claims.put("name", name);
+        }
+        return new Jwt(
+            "token",
+            Instant.parse("2026-01-01T00:00:00Z"),
+            Instant.parse("2026-01-01T01:00:00Z"),
+            Map.of("alg", "none"),
+            claims
+        );
     }
 
     private void assertDtoWasCachedForSubject(String subject) {
@@ -555,19 +402,5 @@ class UserPermissionsServiceV2Test {
         );
         assertThat(dto.getCacheName()).isEqualTo(cacheKey);
         assertThat(payloadCaptor.getValue()).isEqualTo(objectToPrettyJson(dto));
-    }
-
-    private void setAuthenticatedCaller(long callerUserId, String callerSubject) {
-        JwtAuthenticationToken authentication = mock(JwtAuthenticationToken.class);
-        when(authentication.getToken()).thenReturn(jwt);
-        when(securityContext.getAuthentication()).thenReturn(authentication);
-        SecurityContextHolder.setContext(securityContext);
-
-        UserEntity callerUser = UserEntity.builder()
-            .userId(callerUserId)
-            .tokenSubject(callerSubject)
-            .build();
-        when(jwt.getSubject()).thenReturn(callerSubject);
-        when(userRepository.findByTokenSubject(callerSubject)).thenReturn(Optional.of(callerUser));
     }
 }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/PO-6363
"UserService should only update LastLogin, Activation Date and authentication events if getting user state for id 0"

### Changes:
- `GET /v2/users/{id}/state` is now explicitly current-user only: non-zero IDs are rejected with 400 Bad Request.
- UserPermissionsService.getUserStateV2 was simplified to getUserStateV2(boolean newLogin) and now always looks up the user from JWT sub.
- OpenAPI docs were updated to state that id must be 0 and to document the bad-request behaviour for non-zero IDs.

**Does this PR introduce a breaking change?** (check one with "x")

```
[   ] Yes
[ X] No
```
