### PR TITLE
PO-6384 : auth null check

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/opal/service/UserPermissionsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/service/UserPermissionsService.java
@@ -22,7 +22,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -51,22 +50,6 @@ import uk.gov.hmcts.reform.opal.repository.UserRepository;
 import uk.gov.hmcts.reform.opal.service.opal.UserService;
 import uk.gov.hmcts.reform.opal.service.synchronise.SynchronisePermissionsService;
 
-import java.time.Clock;
-import java.time.LocalDateTime;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
-import static uk.gov.hmcts.opal.common.dto.ToJsonString.objectToPrettyJson;
-import static uk.gov.hmcts.opal.common.logging.LogUtil.getRequestTimestamp;
-import static uk.gov.hmcts.reform.opal.util.VersionUtils.verifyIfMatch;
-
-
 @Service
 @RequiredArgsConstructor
 @Slf4j(topic = "opal.UserPermissionsService")
@@ -90,15 +73,6 @@ public class UserPermissionsService {
     private final SynchronisePermissionsService synchronisePermissionsService;
     private final AppModeConfiguration appModeConfiguration;
     private final UserService userService;
-
-    @Transactional(readOnly = true)
-    public Long getAuthenticatedUserId() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null) {
-            throw new AccessDeniedException("No authenticated user found in the security context.");
-        }
-        return getUserId(authentication);
-    }
 
     @Transactional
     public UserStateV2Dto getUserStateV2(Long userId, Boolean newLogin) {
@@ -126,8 +100,7 @@ public class UserPermissionsService {
         if (Optional.ofNullable(newLogin).orElse(false)) {
             Long authenticationEventUserId = user.getUserId();
             if (userId != 0) {
-                Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-                authenticationEventUserId = getUserId(authentication);
+                authenticationEventUserId = getAuthenticatedUserId();
             }
             logUserAuthenticationEvent(authenticationEventUserId);
             updateLastLogin(user);
@@ -139,8 +112,7 @@ public class UserPermissionsService {
     }
 
     private UserEntity getAndValidateAuthenticatedUser() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Jwt jwt = getJwtToken(authentication);
+        Jwt jwt = getJwtToken();
         String subject = extractSubject(jwt);
 
         UserEntity user = userRepository.findByTokenSubject(subject)
@@ -154,8 +126,8 @@ public class UserPermissionsService {
     }
 
     @Transactional(readOnly = true)
-    public Long getUserId(Authentication authentication) {
-        Jwt jwt = getJwtToken(authentication);
+    public Long getAuthenticatedUserId() {
+        Jwt jwt = getJwtToken();
         String subject = extractSubject(jwt);
         UserEntity user = getUser(subject);
         return user.getUserId();
@@ -308,7 +280,12 @@ public class UserPermissionsService {
         return userMapper.toUserDto(updatedUser, clock);
     }
 
-    public Jwt getJwtToken(Authentication authentication) {
+    public Jwt getJwtToken() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null) {
+            log.warn(":getJwtToken: Authentication is null.");
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Authentication not found.");
+        }
         if (authentication instanceof JwtAuthenticationToken jwtAuth) {
             return jwtAuth.getToken();
         } else {

--- a/src/test/java/uk/gov/hmcts/reform/opal/service/UserPermissionsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/opal/service/UserPermissionsServiceTest.java
@@ -13,8 +13,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
@@ -115,21 +113,6 @@ class UserPermissionsServiceTest {
     }
 
     @Test
-    @DisplayName("getUserId(String) from Authentication object")
-    void testGetUserId() {
-        // Arrange
-        JwtAuthenticationToken jwtAuthToken = createJwtAuthenticatedToken();
-        when(userRepository.findByTokenSubject(any())).thenReturn(java.util.Optional.of(userEntity));
-
-        // Act
-        long result = service.getUserId(jwtAuthToken);
-
-        // Assert
-        assertEquals(USER_ID, result);
-        verify(userRepository).findByTokenSubject(any());
-    }
-
-    @Test
     @DisplayName("getAuthenticatedUserId returns current authenticated user id")
     void testGetAuthenticatedUserId() {
         JwtAuthenticationToken jwtAuthToken = createJwtAuthenticatedToken();
@@ -147,12 +130,12 @@ class UserPermissionsServiceTest {
     void testGetAuthenticatedUserId_throwsWhenAuthenticationMissing() {
         SecurityContextHolder.clearContext();
 
-        AccessDeniedException ex = assertThrows(
-            AccessDeniedException.class,
+        ResponseStatusException ex = assertThrows(
+            ResponseStatusException.class,
             () -> service.getAuthenticatedUserId()
         );
 
-        assertEquals("No authenticated user found in the security context.", ex.getMessage());
+        assertEquals("401 UNAUTHORIZED \"Authentication not found.\"", ex.getMessage());
     }
 
     @Test
@@ -297,15 +280,13 @@ class UserPermissionsServiceTest {
 
     @Test
     void testgetJwtToken_fail_incorrectAuthenticationToken() {
-        // Arrange
-        TestingAuthenticationToken testToken = new TestingAuthenticationToken(null, null);
 
         // Act & Assert
         ResponseStatusException ex = assertThrows(
             ResponseStatusException.class,
-            () -> service.getJwtToken(testToken)
+            () -> service.getJwtToken()
         );
-        assertEquals("401 UNAUTHORIZED \"Authentication Token not of type Jwt.\"", ex.getMessage());
+        assertEquals("401 UNAUTHORIZED \"Authentication not found.\"", ex.getMessage());
     }
 
     @AfterEach

--- a/src/test/java/uk/gov/hmcts/reform/opal/service/UserPermissionsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/opal/service/UserPermissionsServiceTest.java
@@ -13,6 +13,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
@@ -280,8 +281,21 @@ class UserPermissionsServiceTest {
 
     @Test
     void testgetJwtToken_fail_incorrectAuthenticationToken() {
+        SecurityContextHolder.getContext().setAuthentication(
+            new TestingAuthenticationToken("principal", "credentials"));
 
         // Act & Assert
+        ResponseStatusException ex = assertThrows(
+            ResponseStatusException.class,
+            () -> service.getJwtToken()
+        );
+        assertEquals("401 UNAUTHORIZED \"Authentication Token not of type Jwt.\"", ex.getMessage());
+    }
+
+    @Test
+    void testgetJwtToken_fail_authenticationMissing() {
+        SecurityContextHolder.clearContext();
+
         ResponseStatusException ex = assertThrows(
             ResponseStatusException.class,
             () -> service.getJwtToken()


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/PO-6384
"BE - Performance - Perf Test - "authentication" is null Error"

The getUserState endpoint is erroring when the user has no authentication (so throws 500). 
With this PR we spot missing authentication and throw a 401, as we do for other auth issues.

Changes:

- UserPermissionsService now has getJwtToken() with no args; it reads Authentication from SecurityContextHolder directly.
- Added explicit null-auth handling in getJwtToken() to throw 401 UNAUTHORIZED with "Authentication not found.".

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
