### PR TITLE
PO-6411: Introduce feature flag for V2 user state endpoint

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/opal/actions/Release1aFeatureToggleActions.java
+++ b/src/functionalTest/java/uk/gov/hmcts/opal/actions/Release1aFeatureToggleActions.java
@@ -94,7 +94,7 @@ public final class Release1aFeatureToggleActions {
      * @param baseUri base URL of the service under test.
      */
     public static void getCurrentUserState(String baseUri) {
-        record(TestHttpClient.get(baseUri + "/users/state", Map.of("Content-Type", JSON_CONTENT_TYPE)));
+        record(TestHttpClient.get(baseUri + "/v2/users/0/state", Map.of("Content-Type", JSON_CONTENT_TYPE)));
     }
 
     /**
@@ -105,7 +105,7 @@ public final class Release1aFeatureToggleActions {
      */
     public static void getUserStateById(String baseUri, long userId) {
         record(TestHttpClient.get(
-            baseUri + "/users/" + userId + "/state", Map.of("Content-Type", JSON_CONTENT_TYPE)));
+            baseUri + "/v2/users/" + userId + "/state", Map.of("Content-Type", JSON_CONTENT_TYPE)));
     }
 
     /**

--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/Release1AFeatureToggleDisabledIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/Release1AFeatureToggleDisabledIntegrationTest.java
@@ -43,10 +43,10 @@ import uk.gov.hmcts.reform.opal.service.opal.UserService;
 @ContextConfiguration(classes = {
     TestingSupportController.class, UserPermissionsController.class, UserPermissionsV2Controller.class,
     FeatureToggleAspect.class,
-    OpalGlobalExceptionHandler.class, Release1AFeatureToggleIntegrationTest.TestAopConfiguration.class})
-@Import(Release1AFeatureToggleIntegrationTest.TestAopConfiguration.class)
+    OpalGlobalExceptionHandler.class, Release1AFeatureToggleDisabledIntegrationTest.TestAopConfiguration.class})
+@Import(Release1AFeatureToggleDisabledIntegrationTest.TestAopConfiguration.class)
 @DisplayName("Release 1A gated endpoints return 405 when disabled")
-class Release1AFeatureToggleIntegrationTest {
+class Release1AFeatureToggleDisabledIntegrationTest {
 
     private static final String AUTHORIZATION = "Authorization";
     private static final String AUTHORIZATION_VALUE = "Bearer test";
@@ -102,7 +102,7 @@ class Release1AFeatureToggleIntegrationTest {
             args("PUT /users/{userId}", put("/users/500000002")
                 .header(AUTHORIZATION, AUTHORIZATION_VALUE)
                 .header(IF_MATCH, IF_MATCH_VALUE)),
-            args("GET /v2/users/{userId}/state", get("/v2/users/500000003/state"))
+            args("GET /v2/users/{userId}/state", get("/v2/users/0/state"))
         );
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/Release1AFeatureToggleEnabledIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/Release1AFeatureToggleEnabledIntegrationTest.java
@@ -1,0 +1,71 @@
+package uk.gov.hmcts.reform.opal.controllers;
+
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.hmcts.opal.common.controllers.advice.OpalGlobalExceptionHandler;
+import uk.gov.hmcts.opal.common.launchdarkly.FeatureToggleAspect;
+import uk.gov.hmcts.opal.common.launchdarkly.service.FeatureToggleApi;
+import uk.gov.hmcts.opal.common.user.authorisation.client.dto.UserStateV2Dto;
+import uk.gov.hmcts.reform.opal.service.UserPermissionsService;
+
+@WebMvcTest
+@ActiveProfiles({"integration"})
+@ContextConfiguration(classes = {
+    UserPermissionsV2Controller.class,
+    FeatureToggleAspect.class,
+    OpalGlobalExceptionHandler.class,
+    Release1AFeatureToggleEnabledIntegrationTest.TestAopConfiguration.class})
+@Import(Release1AFeatureToggleEnabledIntegrationTest.TestAopConfiguration.class)
+@DisplayName("Release 1A gated endpoints reach the controller when enabled")
+class Release1AFeatureToggleEnabledIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private FeatureToggleApi featureToggleApi;
+
+    @MockitoBean
+    private UserPermissionsService userPermissionsService;
+
+    @BeforeEach
+    void setUpFeatureEnabled() {
+        when(featureToggleApi.isFeatureEnabledWithPropertyValueDefault(anyString(), anyString(), anyBoolean()))
+            .thenReturn(true);
+        when(userPermissionsService.getUserStateV2(false)).thenReturn(new UserStateV2Dto());
+    }
+
+    @Test
+    @DisplayName("GET /v2/users/{userId}/state returns 200 for user id 0 when enabled")
+    void getUserStateV2_whenRelease1aEnabledAndUserIdIsZero_returnsOk() throws Exception {
+        mockMvc.perform(get("/v2/users/0/state"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+
+        verify(userPermissionsService).getUserStateV2(false);
+    }
+
+    @TestConfiguration
+    @EnableAspectJAutoProxy(proxyTargetClass = true)
+    static class TestAopConfiguration {
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/Release1AFeatureToggleIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/Release1AFeatureToggleIntegrationTest.java
@@ -41,7 +41,8 @@ import uk.gov.hmcts.reform.opal.service.opal.UserService;
 @WebMvcTest
 @ActiveProfiles({"integration"})
 @ContextConfiguration(classes = {
-    TestingSupportController.class, UserPermissionsController.class, FeatureToggleAspect.class,
+    TestingSupportController.class, UserPermissionsController.class, UserPermissionsV2Controller.class,
+    FeatureToggleAspect.class,
     OpalGlobalExceptionHandler.class, Release1AFeatureToggleIntegrationTest.TestAopConfiguration.class})
 @Import(Release1AFeatureToggleIntegrationTest.TestAopConfiguration.class)
 @DisplayName("Release 1A gated endpoints return 405 when disabled")
@@ -100,7 +101,8 @@ class Release1AFeatureToggleIntegrationTest {
                 .header(IF_MATCH, IF_MATCH_VALUE)),
             args("PUT /users/{userId}", put("/users/500000002")
                 .header(AUTHORIZATION, AUTHORIZATION_VALUE)
-                .header(IF_MATCH, IF_MATCH_VALUE))
+                .header(IF_MATCH, IF_MATCH_VALUE)),
+            args("GET /v2/users/{userId}/state", get("/v2/users/500000003/state"))
         );
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/opal/controllers/UserPermissionsV2Controller.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/controllers/UserPermissionsV2Controller.java
@@ -10,10 +10,13 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.hmcts.opal.common.launchdarkly.FeatureToggle;
 import uk.gov.hmcts.opal.common.user.authorisation.client.dto.UserStateV2Dto;
 import uk.gov.hmcts.reform.opal.service.UserPermissionsService;
 
 import static uk.gov.hmcts.reform.opal.util.HttpUtil.buildResponse;
+import static uk.gov.hmcts.reform.opal.util.FeatureFlags.RELEASE_1A;
+import static uk.gov.hmcts.reform.opal.util.FeatureFlags.RELEASE_1A_ENABLED_PROPERTY;
 
 @RestController
 @RequestMapping("/v2/users")
@@ -26,6 +29,7 @@ public class UserPermissionsV2Controller {
     private final UserPermissionsService userPermissionsService;
 
     @GetMapping("/{userId}/state")
+    @FeatureToggle(feature = RELEASE_1A, defaultValueProperty = RELEASE_1A_ENABLED_PROPERTY)
     public ResponseEntity<UserStateV2Dto> getUserStateV2(
         @PathVariable Long userId,
         @RequestHeader(value = X_NEW_LOGIN, required = false) Boolean newLogin) {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-6411


### Change description ###
- Gated `GET /v2/users/{userId}/state` behind the release-1a feature toggle.
- Kept the existing response unchanged when the toggle is enabled.
- Returned the standard feature-disabled response when the toggle is disabled.
- Added coverage for both enabled and disabled toggle states.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
