### PR TITLE
PO-6464 : skipping csv rows without 3 columns

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/opal/service/rolemapping/UserRoleMappingParser.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/service/rolemapping/UserRoleMappingParser.java
@@ -40,7 +40,7 @@ public class UserRoleMappingParser {
             for (CSVRecord record : parser) {
 
                 // --- Skip malformed rows ---
-                if (record.size() < 3) {
+                if (record.size() != 3) {
                     log.warn("Skipping malformed CSV row {}: {}", record.getRecordNumber(), record);
                     continue;
                 }

--- a/src/test/java/uk/gov/hmcts/reform/opal/service/rolemapping/UserRoleMappingParserTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/opal/service/rolemapping/UserRoleMappingParserTest.java
@@ -142,6 +142,31 @@ class UserRoleMappingParserTest {
     }
 
     @Test
+    @DisplayName("Skips rows with extra columns instead of throwing")
+    void skipsRowsWithExtraColumns() throws Exception {
+
+        // ARRANGE
+        String csv = """
+                email_address,business_unit_id,role_id
+                user1@test.com,BU1,R2,,
+                user2@test.com,BU2,R2
+                """;
+
+        // ACT
+        MappingFileProcessingResult result = parser.parse(new StringReader(csv));
+
+        // ASSERT
+        assertEquals(1, result.validUsers().size());
+
+        ParsedUserMapping user2 = result.validUsers().get(0);
+
+        assertEquals("user2@test.com", user2.emailAddress());
+        assertEquals(Map.of(
+            "R2", Set.of("BU2")
+        ), user2.roleToBusinessUnits());
+    }
+
+    @Test
     @DisplayName("Ignores rows for email already marked invalid even if contiguous afterwards")
     void ignoresRowsForEmailAlreadyMarkedInvalidEvenIfContiguousAfterwards() throws Exception {
 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/PO-6464
="Invalid CSV with additional commas processed without raising errors"

Changes

We now skip CSV rows (and log a WARN level message) if the column count is not 3.
Before this only happend if the column count was less than 3.


**Does this PR introduce a breaking change?** (check one with "x")

```
[   ] Yes
[ X ] No
```
