### PR TITLE
PO-6472 : ignoring invalid roles in cache

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/UserPermissionsV2LegacySyncIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/UserPermissionsV2LegacySyncIntegrationTest.java
@@ -10,6 +10,7 @@ import org.springframework.test.context.jdbc.Sql;
 import uk.gov.hmcts.reform.opal.AbstractLegacyWireMockIntegrationTest;
 import uk.gov.hmcts.reform.opal.entity.UserEntity;
 import uk.gov.hmcts.reform.opal.repository.UserRepository;
+import uk.gov.hmcts.reform.opal.service.rolemapping.UserRoleMappingCacheService;
 import uk.gov.hmcts.reform.opal.service.synchronise.TestHelperService;
 import uk.gov.hmcts.reform.opal.service.synchronise.TestHelperUtil;
 
@@ -53,6 +54,9 @@ class UserPermissionsV2LegacySyncIntegrationTest extends AbstractLegacyWireMockI
 
     @Autowired
     private TestHelperService helper;
+
+    @Autowired
+    private UserRoleMappingCacheService userRoleMappingCacheService;
 
     @BeforeEach
     void initialiseEachTest() throws Exception {
@@ -100,6 +104,36 @@ class UserPermissionsV2LegacySyncIntegrationTest extends AbstractLegacyWireMockI
         mockMvc.perform(get(CURRENT_USER_STATE_URI));
 
         helper.assertBusinessUnitUserRow(BUSINESS_UNIT_USER_ID, BUSINESS_UNIT_ID, USER_ID, ROLE_ID, 1L);
+        assertThat(helper.getLoggedBusinessEventTypes()).containsExactly(
+            ROLE_ASSIGNED_TO_USER,
+            ACCOUNT_ACTIVATION_INITIATED
+        );
+    }
+
+    @Test
+    @DisplayName("AC2b: should ignore invalid cached role ids and still return user state")
+    void getUserStateV2_ignoresInvalidCachedRoleIdsAndReturnsUserState() throws Exception {
+        UserEntity user = userRepository.findById(USER_ID).orElseThrow();
+        TestHelperUtil.setAuthenticatedUser(user);
+        legacyWireMockXmlStubHelper.registerBusinessUnitUserLookupStub(
+            List.of(TestHelperUtil.legacyBusinessUnitUser(BUSINESS_UNIT_USER_ID, BUSINESS_UNIT_ID))
+        );
+        userRoleMappingCacheService.putUserMapping(
+            user.getTokenSubject(),
+            Map.of(
+                "1", Set.of("69"),
+                "999", Set.of("70")
+            )
+        );
+
+        mockMvc.perform(get(CURRENT_USER_STATE_URI))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.domains.fines.business_unit_users[0].business_unit_id")
+                           .value((int) BUSINESS_UNIT_ID));
+
+        helper.assertBusinessUnitUserRow(BUSINESS_UNIT_USER_ID, BUSINESS_UNIT_ID, USER_ID, ROLE_ID, 1L);
+        assertThat(helper.countRoleAssignments(user.getUserId())).isEqualTo(1L);
         assertThat(helper.getLoggedBusinessEventTypes()).containsExactly(
             ROLE_ASSIGNED_TO_USER,
             ACCOUNT_ACTIVATION_INITIATED

--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/service/synchronise/RoleMappingCacheLookupServiceIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/service/synchronise/RoleMappingCacheLookupServiceIntegrationTest.java
@@ -66,7 +66,8 @@ class RoleMappingCacheLookupServiceIntegrationTest extends AbstractIntegrationTe
             TOKEN_SUBJECT,
             Map.of(
                 "2", Set.of("68"),
-                "999", Set.of("70")
+                "999", Set.of("70"),
+                "1", Set.of("69")
             )
         );
 
@@ -75,7 +76,7 @@ class RoleMappingCacheLookupServiceIntegrationTest extends AbstractIntegrationTe
                 TestHelperUtil.buildUser(USER_ID, TOKEN_SUBJECT)
             );
 
-            assertThat(result).isEqualTo(Map.of(2L, Set.of((short) 68)));
+            assertThat(result).isEqualTo(Map.of(2L, Set.of((short) 68),1L, Set.of((short) 69)));
         } finally {
             userRoleMappingCacheService.deleteUserMapping(TOKEN_SUBJECT);
         }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/service/synchronise/RoleMappingCacheLookupServiceIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/service/synchronise/RoleMappingCacheLookupServiceIntegrationTest.java
@@ -40,8 +40,8 @@ class RoleMappingCacheLookupServiceIntegrationTest extends AbstractIntegrationTe
         userRoleMappingCacheService.putUserMapping(
             TOKEN_SUBJECT,
             Map.of(
-                "101", Set.of("7", "8"),
-                "202", Set.of("9")
+                "1", Set.of("7", "8"),
+                "2", Set.of("9")
             )
         );
 
@@ -51,9 +51,31 @@ class RoleMappingCacheLookupServiceIntegrationTest extends AbstractIntegrationTe
             );
 
             assertThat(result).isEqualTo(Map.of(
-                101L, Set.of((short) 7, (short) 8),
-                202L, Set.of((short) 9)
+                1L, Set.of((short) 7, (short) 8),
+                2L, Set.of((short) 9)
             ));
+        } finally {
+            userRoleMappingCacheService.deleteUserMapping(TOKEN_SUBJECT);
+        }
+    }
+
+    @Test
+    @DisplayName("Should skip invalid roles and keep valid roles when Redis contains mixed role ids")
+    void getRoleMappingByTokenSubject_skipsInvalidRoleIdsAndKeepsValidRoleIds() throws Exception {
+        userRoleMappingCacheService.putUserMapping(
+            TOKEN_SUBJECT,
+            Map.of(
+                "2", Set.of("68"),
+                "999", Set.of("70")
+            )
+        );
+
+        try {
+            Map<Long, Set<Short>> result = roleMappingCacheLookupService.getRoleMappingByTokenSubject(
+                TestHelperUtil.buildUser(USER_ID, TOKEN_SUBJECT)
+            );
+
+            assertThat(result).isEqualTo(Map.of(2L, Set.of((short) 68)));
         } finally {
             userRoleMappingCacheService.deleteUserMapping(TOKEN_SUBJECT);
         }

--- a/src/main/java/uk/gov/hmcts/reform/opal/service/opal/RoleService.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/service/opal/RoleService.java
@@ -37,6 +37,11 @@ public class RoleService {
     }
 
     @Transactional(readOnly = true)
+    public boolean roleExists(long roleId) {
+        return roleRepository.existsById(roleId);
+    }
+
+    @Transactional(readOnly = true)
     public List<BusinessUnitUserEntity> getAlignedBusinessUnitUsers(Long userId, Set<Short> businessUnitIds) {
         if (businessUnitIds.isEmpty()) {
             return List.of();

--- a/src/main/java/uk/gov/hmcts/reform/opal/service/synchronise/RoleMappingCacheLookupService.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/service/synchronise/RoleMappingCacheLookupService.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.opal.service.synchronise;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -81,9 +80,7 @@ public class RoleMappingCacheLookupService {
         Map<Long, Set<Short>> converted = new HashMap<>();
         for (Map.Entry<String, Set<String>> entry : cacheMap.entrySet()) {
             Long roleId = parseRoleId(user, entry.getKey());
-            try {
-                roleService.requireRole(roleId);
-            }  catch (EntityNotFoundException exception) {
+            if (!roleService.roleExists(roleId)) {
                 log.warn("Cache roleId not found in database. user: {} roleId: {}", user.getTokenSubject(), roleId);
                 continue;
             }

--- a/src/main/java/uk/gov/hmcts/reform/opal/service/synchronise/RoleMappingCacheLookupService.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/service/synchronise/RoleMappingCacheLookupService.java
@@ -3,10 +3,12 @@ package uk.gov.hmcts.reform.opal.service.synchronise;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.opal.entity.UserEntity;
+import uk.gov.hmcts.reform.opal.service.opal.RoleService;
 import uk.gov.hmcts.reform.opal.service.rolemapping.UserRoleMappingCacheService;
 
 import java.util.HashMap;
@@ -23,6 +25,7 @@ public class RoleMappingCacheLookupService {
     private static final String UNEXPECTED_RUNTIME_EXCEPTION_REASON = "unexpected runtime exception";
 
     private final UserRoleMappingCacheService userRoleMappingCacheService;
+    private final RoleService roleService;
     private final ObjectMapper objectMapper;
 
     /**
@@ -77,6 +80,13 @@ public class RoleMappingCacheLookupService {
         Map<Long, Set<Short>> converted = new HashMap<>();
         for (Map.Entry<String, Set<String>> entry : cacheMap.entrySet()) {
             Long roleId = parseRoleId(user, entry.getKey());
+            try {
+                roleService.requireRole(roleId);
+            }  catch (EntityNotFoundException exception) {
+                log.warn("Cache roleId not found in database. user: {} roleId: {}", user.getTokenSubject(), roleId);
+                continue;
+            }
+
             if (entry.getValue() == null) {
                 log.warn("Role {} has null business unit ids in cache for user {}. Treating as empty set.",
                          entry.getKey(), user.getUserId());

--- a/src/main/java/uk/gov/hmcts/reform/opal/service/synchronise/RoleMappingCacheLookupService.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/service/synchronise/RoleMappingCacheLookupService.java
@@ -75,6 +75,7 @@ public class RoleMappingCacheLookupService {
      *                 {@link String}
      * @return map keyed by role id as {@link Long}, with values containing business unit ids as {@link Short}
      */
+    @SuppressWarnings("java:S135")
     private Map<Long, Set<Short>> convertCacheMap(UserEntity user, Map<String, Set<String>> cacheMap) {
 
         Map<Long, Set<Short>> converted = new HashMap<>();

--- a/src/test/java/uk/gov/hmcts/reform/opal/service/opal/RoleServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/opal/service/opal/RoleServiceTest.java
@@ -64,6 +64,20 @@ class RoleServiceTest {
     }
 
     @Test
+    void roleExists_whenRoleExists_returnsTrue() {
+        when(roleRepository.existsById(101L)).thenReturn(true);
+
+        assertEquals(true, roleService.roleExists(101L));
+    }
+
+    @Test
+    void roleExists_whenRoleDoesNotExist_returnsFalse() {
+        when(roleRepository.existsById(101L)).thenReturn(false);
+
+        assertEquals(false, roleService.roleExists(101L));
+    }
+
+    @Test
     void getAlignedBusinessUnitUsers_whenAllBusinessUnitsAreAligned_returnsBusinessUnitUsers() {
         BusinessUnitUserEntity buu1 = businessUnitUser("BU001", 1L, (short) 11);
         BusinessUnitUserEntity buu2 = businessUnitUser("BU002", 1L, (short) 12);

--- a/src/test/java/uk/gov/hmcts/reform/opal/service/synchronise/RoleMappingCacheLookupServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/opal/service/synchronise/RoleMappingCacheLookupServiceTest.java
@@ -10,7 +10,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.opal.entity.UserEntity;
-import uk.gov.hmcts.reform.opal.entity.RoleEntity;
 import uk.gov.hmcts.reform.opal.service.opal.RoleService;
 import uk.gov.hmcts.reform.opal.service.rolemapping.UserRoleMappingCacheService;
 
@@ -75,6 +74,8 @@ class RoleMappingCacheLookupServiceTest {
         );
         when(userRoleMappingCacheService.getUserMapping(TOKEN_SUBJECT)).thenReturn(cachePayload);
         when(objectMapper.readValue(eq(cachePayload), roleMappingCacheTypeReference())).thenReturn(cacheMap);
+        when(roleService.roleExists(101L)).thenReturn(true);
+        when(roleService.roleExists(202L)).thenReturn(true);
 
         // Act
         Map<Long, Set<Short>> result = roleMappingCacheLookupService.getRoleMappingByTokenSubject(user());
@@ -173,6 +174,7 @@ class RoleMappingCacheLookupServiceTest {
         cacheMap.put("101", null);
         when(userRoleMappingCacheService.getUserMapping(TOKEN_SUBJECT)).thenReturn(cachePayload);
         when(objectMapper.readValue(eq(cachePayload), roleMappingCacheTypeReference())).thenReturn(cacheMap);
+        when(roleService.roleExists(101L)).thenReturn(true);
 
         // Act
         Map<Long, Set<Short>> result = roleMappingCacheLookupService.getRoleMappingByTokenSubject(user());
@@ -193,9 +195,9 @@ class RoleMappingCacheLookupServiceTest {
         );
         when(userRoleMappingCacheService.getUserMapping(TOKEN_SUBJECT)).thenReturn(cachePayload);
         when(objectMapper.readValue(eq(cachePayload), roleMappingCacheTypeReference())).thenReturn(cacheMap);
-        when(roleService.requireRole(101L)).thenReturn(RoleEntity.builder().roleId(101L).build());
-        when(roleService.requireRole(202L)).thenReturn(RoleEntity.builder().roleId(202L).build());
-        when(roleService.requireRole(999L)).thenThrow(new jakarta.persistence.EntityNotFoundException("missing"));
+        when(roleService.roleExists(101L)).thenReturn(true);
+        when(roleService.roleExists(202L)).thenReturn(true);
+        when(roleService.roleExists(999L)).thenReturn(false);
 
         // Act
         Map<Long, Set<Short>> result = roleMappingCacheLookupService.getRoleMappingByTokenSubject(user());
@@ -230,6 +232,7 @@ class RoleMappingCacheLookupServiceTest {
         Map<String, Set<String>> cacheMap = Map.of("101", Set.of("business-unit-7"));
         when(userRoleMappingCacheService.getUserMapping(TOKEN_SUBJECT)).thenReturn(cachePayload);
         when(objectMapper.readValue(eq(cachePayload), roleMappingCacheTypeReference())).thenReturn(cacheMap);
+        when(roleService.roleExists(101L)).thenReturn(true);
 
         // Act / Assert
         assertThrows(

--- a/src/test/java/uk/gov/hmcts/reform/opal/service/synchronise/RoleMappingCacheLookupServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/opal/service/synchronise/RoleMappingCacheLookupServiceTest.java
@@ -10,6 +10,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.opal.entity.UserEntity;
+import uk.gov.hmcts.reform.opal.entity.RoleEntity;
+import uk.gov.hmcts.reform.opal.service.opal.RoleService;
 import uk.gov.hmcts.reform.opal.service.rolemapping.UserRoleMappingCacheService;
 
 import java.lang.reflect.Type;
@@ -40,6 +42,9 @@ class RoleMappingCacheLookupServiceTest {
 
     @Mock
     private ObjectMapper objectMapper;
+
+    @Mock
+    private RoleService roleService;
 
     @InjectMocks
     private RoleMappingCacheLookupService roleMappingCacheLookupService;
@@ -174,6 +179,28 @@ class RoleMappingCacheLookupServiceTest {
 
         // Assert
         assertEquals(Map.of(101L, Set.of()), result);
+    }
+
+    @Test
+    void getRoleMappingByTokenSubject_skipsInvalidRolesAndKeepsValidRoles() throws Exception {
+
+        // Arrange
+        String cachePayload = "{\"101\":[\"7\"],\"999\":[\"8\"]}";
+        Map<String, Set<String>> cacheMap = Map.of(
+            "101", Set.of("7"),
+            "999", Set.of("8")
+        );
+        when(userRoleMappingCacheService.getUserMapping(TOKEN_SUBJECT)).thenReturn(cachePayload);
+        when(objectMapper.readValue(eq(cachePayload), roleMappingCacheTypeReference())).thenReturn(cacheMap);
+        when(roleService.requireRole(101L)).thenReturn(RoleEntity.builder().roleId(101L).build());
+        when(roleService.requireRole(999L)).thenThrow(new jakarta.persistence.EntityNotFoundException("missing"));
+
+        // Act
+        Map<Long, Set<Short>> result = roleMappingCacheLookupService.getRoleMappingByTokenSubject(user());
+
+        // Assert
+        assertEquals(Map.of(101L, Set.of((short) 7)), result);
+        verify(userRoleMappingCacheService).getUserMapping(TOKEN_SUBJECT);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/opal/service/synchronise/RoleMappingCacheLookupServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/opal/service/synchronise/RoleMappingCacheLookupServiceTest.java
@@ -185,21 +185,23 @@ class RoleMappingCacheLookupServiceTest {
     void getRoleMappingByTokenSubject_skipsInvalidRolesAndKeepsValidRoles() throws Exception {
 
         // Arrange
-        String cachePayload = "{\"101\":[\"7\"],\"999\":[\"8\"]}";
+        String cachePayload = "{\"101\":[\"7\"],\"999\":[\"8\"],\"202\":[\"9\"]}";
         Map<String, Set<String>> cacheMap = Map.of(
             "101", Set.of("7"),
-            "999", Set.of("8")
+            "999", Set.of("8"),
+            "202", Set.of("9")
         );
         when(userRoleMappingCacheService.getUserMapping(TOKEN_SUBJECT)).thenReturn(cachePayload);
         when(objectMapper.readValue(eq(cachePayload), roleMappingCacheTypeReference())).thenReturn(cacheMap);
         when(roleService.requireRole(101L)).thenReturn(RoleEntity.builder().roleId(101L).build());
+        when(roleService.requireRole(202L)).thenReturn(RoleEntity.builder().roleId(202L).build());
         when(roleService.requireRole(999L)).thenThrow(new jakarta.persistence.EntityNotFoundException("missing"));
 
         // Act
         Map<Long, Set<Short>> result = roleMappingCacheLookupService.getRoleMappingByTokenSubject(user());
 
         // Assert
-        assertEquals(Map.of(101L, Set.of((short) 7)), result);
+        assertEquals(Map.of(101L, Set.of((short) 7), 202L, Set.of((short) 9)), result);
         verify(userRoleMappingCacheService).getUserMapping(TOKEN_SUBJECT);
     }
 


### PR DESCRIPTION
[PO-6472](https://tools.hmcts.net/jira/browse/PO-6472) : User can't sign in when mapping file entry has one valid and one invalid role

### Changes:

1. We now ignore role ids found in the cache that don't exist in the database.
2. Unit and Integration Tests updated


**Does this PR introduce a breaking change?** (check one with "x")

```
[   ] Yes
[ X  ] No
```
