### PR TITLE
PO-6359: Bump opal-common-lib to 0.3.17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -358,7 +358,7 @@ dependencies {
     }
   }
 
-  implementation('uk.gov.hmcts:opal-common-lib:0.3.15') {
+  implementation('uk.gov.hmcts:opal-common-lib:0.3.17') {
     exclude group: 'com.microsoft.azure', module: 'applicationinsights-spring-boot-starter'
   }
   implementation('uk.gov.hmcts:spring-exception-handler:1.0.1') {

--- a/src/functionalTest/resources/features/toggle/UserServiceRelease1aFeatureToggles.feature
+++ b/src/functionalTest/resources/features/toggle/UserServiceRelease1aFeatureToggles.feature
@@ -4,7 +4,7 @@ Feature: User Service release-1a feature toggles
   @JIRA-STORY:PO-3763 @JIRA-EPIC:PO-3685
   Scenario Outline: Release-1a gated endpoint <endpoint> returns the feature-disabled response when disabled
     When I call the release-1a gated "<endpoint>" endpoint
-    Then The response returns the status code 405
+    Then The response returns the status code 404
     And The response contains the following
       | title  | Feature Disabled                                  |
       | detail | The requested feature is not currently available |

--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/Release1AFeatureToggleDisabledIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/Release1AFeatureToggleDisabledIntegrationTest.java
@@ -45,7 +45,7 @@ import uk.gov.hmcts.reform.opal.service.opal.UserService;
     FeatureToggleAspect.class,
     OpalGlobalExceptionHandler.class, Release1AFeatureToggleDisabledIntegrationTest.TestAopConfiguration.class})
 @Import(Release1AFeatureToggleDisabledIntegrationTest.TestAopConfiguration.class)
-@DisplayName("Release 1A gated endpoints return 405 when disabled")
+@DisplayName("Release 1A gated endpoints return 404 when disabled")
 class Release1AFeatureToggleDisabledIntegrationTest {
 
     private static final String AUTHORIZATION = "Authorization";
@@ -112,7 +112,7 @@ class Release1AFeatureToggleDisabledIntegrationTest {
                                                             MockHttpServletRequestBuilder request)
         throws Exception {
         mockMvc.perform(request)
-            .andExpect(status().isMethodNotAllowed())
+            .andExpect(status().isNotFound())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(jsonPath("$.title").value("Feature Disabled"))
             .andExpect(jsonPath("$.detail").value("The requested feature is not currently available"));

--- a/src/main/java/uk/gov/hmcts/reform/opal/dto/businessevent/RoleAssignedToUserEvent.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/dto/businessevent/RoleAssignedToUserEvent.java
@@ -1,13 +1,10 @@
 package uk.gov.hmcts.reform.opal.dto.businessevent;
 
 import java.util.Set;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.annotation.JsonNaming;
 
-@com.fasterxml.jackson.databind.annotation.JsonNaming(
-    com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy.class
-)
-@tools.jackson.databind.annotation.JsonNaming(
-    tools.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy.class
-)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record RoleAssignedToUserEvent(Long roleId, Long roleVersion,
                                       Set<Short> addedBusinessUnitIds) implements BusinessEvent {
 }

--- a/src/main/java/uk/gov/hmcts/reform/opal/dto/businessevent/RoleAssignedToUserEvent.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/dto/businessevent/RoleAssignedToUserEvent.java
@@ -1,11 +1,13 @@
 package uk.gov.hmcts.reform.opal.dto.businessevent;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-
 import java.util.Set;
 
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@com.fasterxml.jackson.databind.annotation.JsonNaming(
+    com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy.class
+)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy.class
+)
 public record RoleAssignedToUserEvent(Long roleId, Long roleVersion,
                                       Set<Short> addedBusinessUnitIds) implements BusinessEvent {
 }

--- a/src/main/java/uk/gov/hmcts/reform/opal/dto/businessevent/RoleUnassignedFromUserEvent.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/dto/businessevent/RoleUnassignedFromUserEvent.java
@@ -1,13 +1,10 @@
 package uk.gov.hmcts.reform.opal.dto.businessevent;
 
 import java.util.Set;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.annotation.JsonNaming;
 
-@com.fasterxml.jackson.databind.annotation.JsonNaming(
-    com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy.class
-)
-@tools.jackson.databind.annotation.JsonNaming(
-    tools.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy.class
-)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record RoleUnassignedFromUserEvent(
     Long roleId, Set<Short> businessUnitIds, Long roleVersion) implements BusinessEvent {
 }

--- a/src/main/java/uk/gov/hmcts/reform/opal/dto/businessevent/RoleUnassignedFromUserEvent.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/dto/businessevent/RoleUnassignedFromUserEvent.java
@@ -1,11 +1,13 @@
 package uk.gov.hmcts.reform.opal.dto.businessevent;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-
 import java.util.Set;
 
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@com.fasterxml.jackson.databind.annotation.JsonNaming(
+    com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy.class
+)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy.class
+)
 public record RoleUnassignedFromUserEvent(
     Long roleId, Set<Short> businessUnitIds, Long roleVersion) implements BusinessEvent {
 }

--- a/src/main/java/uk/gov/hmcts/reform/opal/dto/businessevent/UnitsAssociatedToRoleAmendedEvent.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/dto/businessevent/UnitsAssociatedToRoleAmendedEvent.java
@@ -1,13 +1,10 @@
 package uk.gov.hmcts.reform.opal.dto.businessevent;
 
 import java.util.Set;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.annotation.JsonNaming;
 
-@com.fasterxml.jackson.databind.annotation.JsonNaming(
-    com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy.class
-)
-@tools.jackson.databind.annotation.JsonNaming(
-    tools.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy.class
-)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record UnitsAssociatedToRoleAmendedEvent(
     Long roleId, Long roleVersion, Set<Short> addedBusinessUnitIds,
     Set<Short> removedBusinessUnitIds) implements BusinessEvent {

--- a/src/main/java/uk/gov/hmcts/reform/opal/dto/businessevent/UnitsAssociatedToRoleAmendedEvent.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/dto/businessevent/UnitsAssociatedToRoleAmendedEvent.java
@@ -1,11 +1,13 @@
 package uk.gov.hmcts.reform.opal.dto.businessevent;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-
 import java.util.Set;
 
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@com.fasterxml.jackson.databind.annotation.JsonNaming(
+    com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy.class
+)
+@tools.jackson.databind.annotation.JsonNaming(
+    tools.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy.class
+)
 public record UnitsAssociatedToRoleAmendedEvent(
     Long roleId, Long roleVersion, Set<Short> addedBusinessUnitIds,
     Set<Short> removedBusinessUnitIds) implements BusinessEvent {

--- a/src/main/java/uk/gov/hmcts/reform/opal/service/JsonSchemaValidationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/service/JsonSchemaValidationService.java
@@ -29,7 +29,6 @@ public class JsonSchemaValidationService {
 
     private static final String PATH_ROOT = "jsonSchemas";
     private static final String CLASSPATH_SCHEMA_LOCATION_PREFIX = "classpath:";
-    //TODO remove once common lib is updated to use tools.jackson
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final Map<String, Schema> schemaCache = HashMap.newHashMap(37);
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-6359


### Change description ###
- Update release-1a disabled endpoint expectations from 405 to 404
- Align integration and functional tests with the new feature-disabled response


**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```
