### PR TITLE
PO-6488 : logging mapping business units ignored as not in legacy

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library("Infrastructure") _
+@Library("Infrastructure")
 
 def type = "java"
 def product = "opal"

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library("Infrastructure")
+@Library("Infrastructure@DTSPO-30114/library-nagger")
 
 def type = "java"
 def product = "opal"

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library("Infrastructure@DTSPO-30114/library-nagger")
+@Library("Infrastructure@2.0.0") _
 
 def type = "java"
 def product = "opal"

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library("Infrastructure@2.0.0") _
+@Library("Infrastructure@2") _
 
 def type = "java"
 def product = "opal"

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library("Infrastructure@2") _
+@Library("Infrastructure") _
 
 def type = "java"
 def product = "opal"

--- a/src/main/java/uk/gov/hmcts/reform/opal/service/synchronise/SynchroniseBusinessUnitUsersService.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/service/synchronise/SynchroniseBusinessUnitUsersService.java
@@ -80,7 +80,7 @@ public class SynchroniseBusinessUnitUsersService {
             List<String> staleBusinessUnitUserIds = staleBusinessUnitUsers.stream()
                 .map(BusinessUnitUserEntity::getBusinessUnitUserId)
                 .toList();
-            log.debug("Deleting business units not in cache for user:{} BUUs:{}", user.getUserId(),
+            log.info("Deleting business units not in cache for user:{} BUUs:{}", user.getUserId(),
                  staleBusinessUnitUserIds);
 
             userService.deleteBusinessUnitUsers(user, staleBusinessUnitUsers);
@@ -154,7 +154,7 @@ public class SynchroniseBusinessUnitUsersService {
             List<String> staleBusinessUnitUserIds = staleBusinessUnitUsers.stream()
                 .map(BusinessUnitUserEntity::getBusinessUnitUserId)
                 .toList();
-            log.debug("Deleting business units not in legacy for user:{} BUUs:{}", user.getUserId(),
+            log.info("Deleting business units not in legacy for user:{} BUUs:{}", user.getUserId(),
                      staleBusinessUnitUserIds);
 
             userService.deleteBusinessUnitUsers(user, staleBusinessUnitUsers);

--- a/src/main/java/uk/gov/hmcts/reform/opal/service/synchronise/SynchronisePermissionsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/service/synchronise/SynchronisePermissionsService.java
@@ -61,7 +61,7 @@ public class SynchronisePermissionsService {
             //7. Call activateUser method if the user does not have an activation date
             if (!validatedRoleIds.isEmpty() && user.getActivationDate() == null) {
                 userService.activateUser(user);
-                log.debug("User activated");
+                log.info("User activated");
             }
         } catch (RuntimeException exception) {
             if (exception instanceof SynchronisePermissionsException synchronisePermissionsException) {

--- a/src/main/java/uk/gov/hmcts/reform/opal/service/synchronise/SynchronisePermissionsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/service/synchronise/SynchronisePermissionsService.java
@@ -34,6 +34,7 @@ public class SynchronisePermissionsService {
 
     @Transactional(propagation = REQUIRES_NEW, rollbackFor = Exception.class)
     public void synchronise(UserEntity detachedUser) {
+        log.info("Synchronizing permissions for userId: {}", detachedUser.getUserId());
         UserEntity user = detachedUser;
         try {
             user = userService.getUser(detachedUser.getUserId());

--- a/src/main/java/uk/gov/hmcts/reform/opal/service/synchronise/SynchroniseRolesService.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/service/synchronise/SynchroniseRolesService.java
@@ -107,7 +107,8 @@ public class SynchroniseRolesService {
                 if (legacyBuIds.contains(buId)) {
                     verifiedBuIds.add(buId);
                 } else {
-                    log.info("Ignoring business unit {} from mapping as not found in legacy. User:{}", buId, user.getUserId());
+                    log.info("Ignoring business unit {} from mapping as not found in legacy. User:{}",
+                             buId, user.getUserId());
                 }
             }
             if (!verifiedBuIds.isEmpty()) {

--- a/src/main/java/uk/gov/hmcts/reform/opal/service/synchronise/SynchroniseRolesService.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/service/synchronise/SynchroniseRolesService.java
@@ -82,7 +82,7 @@ public class SynchroniseRolesService {
                 // Keep only BU ids that appear in both sources:
                 // CSV cache says "user should have role on BU"
                 // legacy says "user currently has BU"
-                return pruneBusinessUnitsNotReturnedByLegacy(roleMap, legacyBuIds);
+                return pruneBusinessUnitsNotReturnedByLegacy(roleMap, legacyBuIds, user);
             } catch (UserMissingFromCacheException e) {
                 log.warn("Nothing in cache for : " + user.getTokenSubject());
                 return Map.of();
@@ -97,7 +97,7 @@ public class SynchroniseRolesService {
     }
 
     private static @NonNull Map<Long, Set<Short>> pruneBusinessUnitsNotReturnedByLegacy(
-        Map<Long, Set<Short>> typedRoleMap, Set<Short> legacyBuIds) {
+        Map<Long, Set<Short>> typedRoleMap, Set<Short> legacyBuIds, UserEntity user) {
         Map<Long, Set<Short>> prunedMap = new LinkedHashMap<>();
         for (Long roleId : typedRoleMap.keySet()) {
             // Core comparison: a BU survives only if it is present in the
@@ -106,6 +106,8 @@ public class SynchroniseRolesService {
             for (Short buId : typedRoleMap.get(roleId)) {
                 if (legacyBuIds.contains(buId)) {
                     verifiedBuIds.add(buId);
+                } else {
+                    log.info("Ignoring business unit {} from mapping as not found in legacy. User:{}", buId, user.getUserId());
                 }
             }
             if (!verifiedBuIds.isEmpty()) {

--- a/src/test/java/uk/gov/hmcts/reform/opal/service/synchronise/SynchroniseBusinessUnitUsersServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/opal/service/synchronise/SynchroniseBusinessUnitUsersServiceTest.java
@@ -1,11 +1,16 @@
 package uk.gov.hmcts.reform.opal.service.synchronise;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 import uk.gov.hmcts.reform.opal.dto.legacy.LegacyBusinessUnitUserId;
 import uk.gov.hmcts.reform.opal.entity.BusinessUnitEntity;
 import uk.gov.hmcts.reform.opal.entity.BusinessUnitUserEntity;
@@ -22,6 +27,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -30,6 +36,8 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class SynchroniseBusinessUnitUsersServiceTest {
+
+    private static final String LOGGER_NAME = "opal.SynchroniseBusinessUnitUsersService";
 
     private static final long USER_ID = 500000001L;
     private static final long DIFFERENT_USER_ID = 500000006L;
@@ -254,18 +262,25 @@ class SynchroniseBusinessUnitUsersServiceTest {
         UserEntity user = user(USER_ID);
         LegacyBusinessUnitUserId legacyBusinessUnitUser = legacyBusinessUnitUser(BUSINESS_UNIT_USER_ID,
             BUSINESS_UNIT_ID);
+        ListAppender<ILoggingEvent> logAppender = attachLogAppender();
 
         // Act
         synchroniseBusinessUnitUsersService.synchroniseBusinessUnitsUsers(user, List.of(legacyBusinessUnitUser));
 
         // Assert
+        assertInfoLogged(
+            logAppender,
+            "Deleting business units not in legacy for user:" + USER_ID + " BUUs:[" + STALE_BUSINESS_UNIT_USER_ID + "]"
+        );
         verify(userService).deleteBusinessUnitUsers(user, List.of(staleBusinessUnitUser));
+        detachLogAppender(logAppender);
     }
 
     @Test
     void synchroniseBusinessUnitUsers_withNoLegacyBusinessUnitUsers_removesAllStaleBusinessUnitUsers() {
 
         // Arrange
+        ListAppender<ILoggingEvent> logAppender = attachLogAppender();
         UserEntity user = user(USER_ID);
         BusinessUnitUserEntity staleBusinessUnitUser = businessUnitUser(
             STALE_BUSINESS_UNIT_USER_ID,
@@ -279,8 +294,13 @@ class SynchroniseBusinessUnitUsersServiceTest {
         synchroniseBusinessUnitUsersService.synchroniseBusinessUnitsUsers(user, List.of());
 
         // Assert
+        assertInfoLogged(
+            logAppender,
+            "Deleting business units not in legacy for user:" + USER_ID + " BUUs:[" + STALE_BUSINESS_UNIT_USER_ID + "]"
+        );
         verify(businessUnitUserRepository).findAllByUser_UserId(USER_ID);
         verify(userService).deleteBusinessUnitUsers(user, List.of(staleBusinessUnitUser));
+        detachLogAppender(logAppender);
     }
 
     @Test
@@ -311,6 +331,7 @@ class SynchroniseBusinessUnitUsersServiceTest {
     void removeBusinessUnitUsersWithoutValidatedRoleMappings_callsUserServiceWithFilteredStaleBusinessUnitUsers() {
 
         // Arrange
+        ListAppender<ILoggingEvent> logAppender = attachLogAppender();
         UserEntity user = user(USER_ID);
         BusinessUnitUserEntity validatedBusinessUnitUser = businessUnitUser(
             BUSINESS_UNIT_USER_ID,
@@ -332,8 +353,13 @@ class SynchroniseBusinessUnitUsersServiceTest {
         );
 
         // Assert
+        assertInfoLogged(
+            logAppender,
+            "Deleting business units not in cache for user:" + USER_ID + " BUUs:[" + STALE_BUSINESS_UNIT_USER_ID + "]"
+        );
         verify(businessUnitUserRepository).findAllByUser_UserId(USER_ID);
         verify(userService).deleteBusinessUnitUsers(user, List.of(staleBusinessUnitUser));
+        detachLogAppender(logAppender);
     }
 
     @Test
@@ -387,6 +413,28 @@ class SynchroniseBusinessUnitUsersServiceTest {
             .businessUnitUserId(businessUnitUserId)
             .businessUnitId(Short.toString(businessUnitId))
             .build();
+    }
+
+    private ListAppender<ILoggingEvent> attachLogAppender() {
+        Logger logger = (Logger) LoggerFactory.getLogger(LOGGER_NAME);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        return appender;
+    }
+
+    private void assertInfoLogged(ListAppender<ILoggingEvent> appender, String expectedMessage) {
+        assertTrue(
+            appender.list.stream()
+                .anyMatch(event -> event.getLevel() == Level.INFO
+                    && expectedMessage.equals(event.getFormattedMessage())),
+            "Expected INFO log message not found: " + expectedMessage
+        );
+    }
+
+    private void detachLogAppender(ListAppender<ILoggingEvent> appender) {
+        Logger logger = (Logger) LoggerFactory.getLogger(LOGGER_NAME);
+        logger.detachAppender(appender);
     }
 
 }


### PR DESCRIPTION
PO-6488
"Partial alignment is persisting only matching combinations but not raising an exception for non-match"

### Changes

1. Logging business units ignored in the cached mapping because they are not present in legacy.
2. Also adjusting some synchronise logging from debug to info so they are more visible. (Discussed this with Ben).

**Does this PR introduce a breaking change?** (check one with "x")

```
[   ] Yes
[ X] No
```
