### PR TITLE
PO-7284 add operation id to all request response headers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -355,7 +355,7 @@ dependencies {
     }
   }
 
-  implementation('uk.gov.hmcts:opal-common-lib:0.3.17') {
+  implementation('uk.gov.hmcts:opal-common-lib:0.3.24') {
     exclude group: 'com.microsoft.azure', module: 'applicationinsights-spring-boot-starter'
   }
   implementation('uk.gov.hmcts:spring-exception-handler:1.0.2') {

--- a/build.gradle
+++ b/build.gradle
@@ -355,7 +355,7 @@ dependencies {
     }
   }
 
-  implementation('uk.gov.hmcts:opal-common-lib:0.3.24') {
+  implementation('uk.gov.hmcts:opal-common-lib:0.3.26') {
     exclude group: 'com.microsoft.azure', module: 'applicationinsights-spring-boot-starter'
   }
   implementation('uk.gov.hmcts:spring-exception-handler:1.0.2') {

--- a/src/functionalTest/java/uk/gov/hmcts/opal/steps/ContentDigestStepDef.java
+++ b/src/functionalTest/java/uk/gov/hmcts/opal/steps/ContentDigestStepDef.java
@@ -16,8 +16,11 @@ import static uk.gov.hmcts.opal.utils.ContentDigestUtils.malformedContentDigestH
 
 public class ContentDigestStepDef extends BaseStepDef {
 
+    private static final String APPLICATION_JSON = "application/json";
     private static final String CONTENT_DIGEST = "Content-Digest";
     private static final String LAST_CONTENT_DIGEST_RESPONSE = "LAST_CONTENT_DIGEST_RESPONSE";
+    private static final String POST_ENDPOINT = "/testing-support/post-user";
+    private static final String POST_BODY = "{}";
 
     @When("I make a content digest request without a Content-Digest header")
     public void getRootWithoutContentDigestHeader() {
@@ -31,12 +34,16 @@ public class ContentDigestStepDef extends BaseStepDef {
 
     @When("I make a content digest request with an invalid Content-Digest header")
     public void getRootWithInvalidContentDigestHeader() {
-        getRoot(Map.of("Accept", "*/*", CONTENT_DIGEST, invalidContentDigestHeader()));
+        post(Map.of("Accept", "*/*",
+            CONTENT_DIGEST, invalidContentDigestHeader(),
+            "Content-Type", APPLICATION_JSON));
     }
 
     @When("I make a content digest request with a malformed Content-Digest header")
     public void getRootWithMalformedContentDigestHeader() {
-        getRoot(Map.of("Accept", "*/*", CONTENT_DIGEST, malformedContentDigestHeader()));
+        post(Map.of("Accept", "*/*",
+            CONTENT_DIGEST, malformedContentDigestHeader(),
+            "Content-Type", APPLICATION_JSON));
     }
 
     @Then("The response has a valid Content-Digest header")
@@ -49,6 +56,13 @@ public class ContentDigestStepDef extends BaseStepDef {
 
     private static void getRoot(Map<String, String> headers) {
         TestHttpResponseDetails response = TestHttpClient.getWithResponseDetails(getTestUrl() + "/", headers);
+        Serenity.setSessionVariable("LAST_RESPONSE").to(response.toTestHttpResponse());
+        Serenity.setSessionVariable(LAST_CONTENT_DIGEST_RESPONSE).to(response);
+    }
+
+    private static void post(Map<String, String> headers) {
+        TestHttpResponseDetails response = TestHttpClient.postWithResponseDetails(
+            getTestUrl() + POST_ENDPOINT, POST_BODY, headers);
         Serenity.setSessionVariable("LAST_RESPONSE").to(response.toTestHttpResponse());
         Serenity.setSessionVariable(LAST_CONTENT_DIGEST_RESPONSE).to(response);
     }

--- a/src/functionalTest/java/uk/gov/hmcts/opal/steps/ContentDigestStepDef.java
+++ b/src/functionalTest/java/uk/gov/hmcts/opal/steps/ContentDigestStepDef.java
@@ -19,7 +19,7 @@ public class ContentDigestStepDef extends BaseStepDef {
     private static final String APPLICATION_JSON = "application/json";
     private static final String CONTENT_DIGEST = "Content-Digest";
     private static final String LAST_CONTENT_DIGEST_RESPONSE = "LAST_CONTENT_DIGEST_RESPONSE";
-    private static final String POST_ENDPOINT = "/testing-support/post-user";
+    private static final String POST_ENDPOINT = "/testing-support/users/500000005";
     private static final String POST_BODY = "{}";
 
     @When("I make a content digest request without a Content-Digest header")
@@ -34,14 +34,14 @@ public class ContentDigestStepDef extends BaseStepDef {
 
     @When("I make a content digest request with an invalid Content-Digest header")
     public void getRootWithInvalidContentDigestHeader() {
-        post(Map.of("Accept", "*/*",
+        patch(Map.of("Accept", "*/*",
             CONTENT_DIGEST, invalidContentDigestHeader(),
             "Content-Type", APPLICATION_JSON));
     }
 
     @When("I make a content digest request with a malformed Content-Digest header")
     public void getRootWithMalformedContentDigestHeader() {
-        post(Map.of("Accept", "*/*",
+        patch(Map.of("Accept", "*/*",
             CONTENT_DIGEST, malformedContentDigestHeader(),
             "Content-Type", APPLICATION_JSON));
     }
@@ -60,8 +60,8 @@ public class ContentDigestStepDef extends BaseStepDef {
         Serenity.setSessionVariable(LAST_CONTENT_DIGEST_RESPONSE).to(response);
     }
 
-    private static void post(Map<String, String> headers) {
-        TestHttpResponseDetails response = TestHttpClient.postWithResponseDetails(
+    private static void patch(Map<String, String> headers) {
+        TestHttpResponseDetails response = TestHttpClient.patchWithResponseDetails(
             getTestUrl() + POST_ENDPOINT, POST_BODY, headers);
         Serenity.setSessionVariable("LAST_RESPONSE").to(response.toTestHttpResponse());
         Serenity.setSessionVariable(LAST_CONTENT_DIGEST_RESPONSE).to(response);

--- a/src/functionalTest/java/uk/gov/hmcts/opal/steps/ContentDigestStepDef.java
+++ b/src/functionalTest/java/uk/gov/hmcts/opal/steps/ContentDigestStepDef.java
@@ -19,8 +19,8 @@ public class ContentDigestStepDef extends BaseStepDef {
     private static final String APPLICATION_JSON = "application/json";
     private static final String CONTENT_DIGEST = "Content-Digest";
     private static final String LAST_CONTENT_DIGEST_RESPONSE = "LAST_CONTENT_DIGEST_RESPONSE";
-    private static final String POST_ENDPOINT = "/testing-support/users/500000005";
-    private static final String POST_BODY = "{}";
+    private static final String PATCH_ENDPOINT = "/testing-support/users/500000005";
+    private static final String PATCH_BODY = "{}";
 
     @When("I make a content digest request without a Content-Digest header")
     public void getRootWithoutContentDigestHeader() {
@@ -62,7 +62,7 @@ public class ContentDigestStepDef extends BaseStepDef {
 
     private static void patch(Map<String, String> headers) {
         TestHttpResponseDetails response = TestHttpClient.patchWithResponseDetails(
-            getTestUrl() + POST_ENDPOINT, POST_BODY, headers);
+            getTestUrl() + PATCH_ENDPOINT, PATCH_BODY, headers);
         Serenity.setSessionVariable("LAST_RESPONSE").to(response.toTestHttpResponse());
         Serenity.setSessionVariable(LAST_CONTENT_DIGEST_RESPONSE).to(response);
     }

--- a/src/functionalTest/java/uk/gov/hmcts/opal/utils/TestHttpClient.java
+++ b/src/functionalTest/java/uk/gov/hmcts/opal/utils/TestHttpClient.java
@@ -58,6 +58,18 @@ public final class TestHttpClient {
         return send(requestBuilder.build());
     }
 
+    public static TestHttpResponseDetails postWithResponseDetails(String url, String body,
+        Map<String, String> headers) {
+        String requestBody = body == null ? "" : body;
+        HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+            .uri(URI.create(url))
+            .POST(HttpRequest.BodyPublishers.ofString(requestBody));
+
+        addHeaders(requestBuilder, headers);
+
+        return sendWithResponseDetails(requestBuilder.build());
+    }
+
     public static TestHttpResponse put(String url, String body, Map<String, String> headers) {
         String requestBody = body == null ? "" : body;
         HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
@@ -113,7 +125,7 @@ public final class TestHttpClient {
             try {
                 JsonNode root = OBJECT_MAPPER.readTree(body);
                 JsonNode node = root.path(fieldName);
-                return node.isMissingNode() || node.isNull() ? null : node.asText();
+                return node.isMissingNode() || node.isNull() ? null : node.asString();
             } catch (JacksonException e) {
                 throw new IllegalStateException("Failed to parse JSON response body", e);
             }

--- a/src/functionalTest/java/uk/gov/hmcts/opal/utils/TestHttpClient.java
+++ b/src/functionalTest/java/uk/gov/hmcts/opal/utils/TestHttpClient.java
@@ -58,18 +58,6 @@ public final class TestHttpClient {
         return send(requestBuilder.build());
     }
 
-    public static TestHttpResponseDetails postWithResponseDetails(String url, String body,
-        Map<String, String> headers) {
-        String requestBody = body == null ? "" : body;
-        HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
-            .uri(URI.create(url))
-            .POST(HttpRequest.BodyPublishers.ofString(requestBody));
-
-        addHeaders(requestBuilder, headers);
-
-        return sendWithResponseDetails(requestBuilder.build());
-    }
-
     public static TestHttpResponse put(String url, String body, Map<String, String> headers) {
         String requestBody = body == null ? "" : body;
         HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
@@ -90,6 +78,18 @@ public final class TestHttpClient {
         addHeaders(requestBuilder, headers);
 
         return send(requestBuilder.build());
+    }
+
+    public static TestHttpResponseDetails patchWithResponseDetails(String url, String body,
+        Map<String, String> headers) {
+        String requestBody = body == null ? "" : body;
+        HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+            .uri(URI.create(url))
+            .method("PATCH", HttpRequest.BodyPublishers.ofString(requestBody));
+
+        addHeaders(requestBuilder, headers);
+
+        return sendWithResponseDetails(requestBuilder.build());
     }
 
     private static void addHeaders(HttpRequest.Builder requestBuilder, Map<String, String> headers) {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/AbstractContentDigestIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/AbstractContentDigestIntegrationTest.java
@@ -15,6 +15,8 @@ abstract class AbstractContentDigestIntegrationTest extends AbstractIntegrationT
 
     protected static final String CONTENT_DIGEST = "Content-Digest";
     protected static final String ROOT_ENDPOINT = "/";
+    protected static final String POST_ENDPOINT = "/users";
+    protected static final String POST_BODY = "{}";
 
     private static final byte[] EMPTY_BODY = new byte[0];
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/ContentDigestRequestAndResponseIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/ContentDigestRequestAndResponseIntegrationTest.java
@@ -5,7 +5,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MvcResult;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @DisplayName("Content-Digest request and response integration tests")
@@ -18,7 +20,10 @@ class ContentDigestRequestAndResponseIntegrationTest extends AbstractContentDige
 
     @Test
     void invalidHeaderWhenEnforced_returnsContentDigestProblemResponse() throws Exception {
-        MvcResult result = mockMvc.perform(get(ROOT_ENDPOINT).header(CONTENT_DIGEST, invalidDigest()))
+        MvcResult result = mockMvc.perform(post(POST_ENDPOINT)
+            .contentType(APPLICATION_JSON)
+            .content(POST_BODY)
+            .header(CONTENT_DIGEST, invalidDigest()))
             .andExpect(status().isBadRequest())
             .andReturn();
 
@@ -29,7 +34,10 @@ class ContentDigestRequestAndResponseIntegrationTest extends AbstractContentDige
 
     @Test
     void malformedHeaderWhenEnforced_returnsContentDigestProblemResponse() throws Exception {
-        MvcResult result = mockMvc.perform(get(ROOT_ENDPOINT).header(CONTENT_DIGEST, malformedDigest()))
+        MvcResult result = mockMvc.perform(post(POST_ENDPOINT)
+            .contentType(APPLICATION_JSON)
+            .content(POST_BODY)
+            .header(CONTENT_DIGEST, malformedDigest()))
             .andExpect(status().isBadRequest())
             .andReturn();
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/ContentDigestResponseGenerationIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/ContentDigestResponseGenerationIntegrationTest.java
@@ -5,7 +5,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MvcResult;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @DisplayName("Content-Digest response generation integration tests")
@@ -27,7 +29,10 @@ class ContentDigestResponseGenerationIntegrationTest extends AbstractContentDige
 
     @Test
     void invalidHeader_returnsContentDigestProblemResponse() throws Exception {
-        MvcResult result = mockMvc.perform(get(ROOT_ENDPOINT).header(CONTENT_DIGEST, invalidDigest()))
+        MvcResult result = mockMvc.perform(post(POST_ENDPOINT)
+            .contentType(APPLICATION_JSON)
+            .content(POST_BODY)
+            .header(CONTENT_DIGEST, invalidDigest()))
             .andExpect(status().isBadRequest())
             .andReturn();
 
@@ -38,7 +43,10 @@ class ContentDigestResponseGenerationIntegrationTest extends AbstractContentDige
 
     @Test
     void malformedHeader_returnsContentDigestProblemResponse() throws Exception {
-        MvcResult result = mockMvc.perform(get(ROOT_ENDPOINT).header(CONTENT_DIGEST, malformedDigest()))
+        MvcResult result = mockMvc.perform(post(POST_ENDPOINT)
+            .contentType(APPLICATION_JSON)
+            .content(POST_BODY)
+            .header(CONTENT_DIGEST, malformedDigest()))
             .andExpect(status().isBadRequest())
             .andReturn();
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/GetWelcomeTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/GetWelcomeTest.java
@@ -4,21 +4,19 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import uk.gov.hmcts.reform.opal.AbstractIntegrationTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest
-@ContextConfiguration(classes = RootController.class)
 @ActiveProfiles({"integration"})
-@Slf4j(topic = "GetWelcomeTest")
-class GetWelcomeTest {
+@Slf4j(topic = "opal.GetWelcomeTest")
+class GetWelcomeTest extends AbstractIntegrationTest {
 
     @Autowired
     private transient MockMvc mockMvc;
@@ -28,7 +26,10 @@ class GetWelcomeTest {
     void welcomeRootEndpoint() throws Exception {
         log.info(":welcomeRootEndpoint:");
         // MvcResult response = mockMvc.perform(get("/")).andExpect(status().isFound()).andReturn();
-        MvcResult response = mockMvc.perform(get("/")).andExpect(status().isOk()).andReturn();
+        MvcResult response = mockMvc.perform(get("/"))
+            .andExpect(header().exists("operation_id"))
+            .andExpect(status().isOk())
+            .andReturn();
 
         assertThat(response.getResponse().getContentAsString()).startsWith("Welcome");
     }

--- a/src/main/java/uk/gov/hmcts/reform/opal/controllers/TestingSupportController.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/controllers/TestingSupportController.java
@@ -9,13 +9,11 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -110,12 +108,6 @@ public class TestingSupportController {
         userService.activateUser(userId, request.activationDate());
 
         return ResponseEntity.noContent().build();
-    }
-
-    @PostMapping(value = "/post-user", consumes = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Void> userPost(@RequestBody Object body) {
-        log.debug(":userPost : body: {}", body);
-        return ResponseEntity.ok().build();
     }
 
     record TestingSupportTokenResponse(@JsonProperty("access_token") String accessToken) {

--- a/src/main/java/uk/gov/hmcts/reform/opal/controllers/TestingSupportController.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/controllers/TestingSupportController.java
@@ -113,9 +113,9 @@ public class TestingSupportController {
     }
 
     @PostMapping(value = "/post-user", consumes = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<?> userPost(@RequestBody Object body) {
+    public ResponseEntity<Void> userPost(@RequestBody Object body) {
         log.debug(":userPost : body: {}", body);
-        return ResponseEntity.ok(body);
+        return ResponseEntity.ok().build();
     }
 
     record TestingSupportTokenResponse(@JsonProperty("access_token") String accessToken) {

--- a/src/main/java/uk/gov/hmcts/reform/opal/controllers/TestingSupportController.java
+++ b/src/main/java/uk/gov/hmcts/reform/opal/controllers/TestingSupportController.java
@@ -9,11 +9,13 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -108,6 +110,12 @@ public class TestingSupportController {
         userService.activateUser(userId, request.activationDate());
 
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping(value = "/post-user", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> userPost(@RequestBody Object body) {
+        log.debug(":userPost : body: {}", body);
+        return ResponseEntity.ok(body);
     }
 
     record TestingSupportTokenResponse(@JsonProperty("access_token") String accessToken) {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-7284


### Change description ###
- Updates the version of opal-common-lib to 0.3.26 so that the OperationIdResponseFilter can attach Operation IDs to all responses.
- Fixes content digest tests that were broken by the opal-common-lib version bump. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
