### PR TITLE
Set OPAL_COMMON_CONTENT_DIGEST_REQUEST_AUTO_GENERATE to 'true' in app…

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/ContentDigestIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/opal/controllers/ContentDigestIntegrationTest.java
@@ -11,9 +11,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class ContentDigestIntegrationTest extends AbstractContentDigestIntegrationTest {
 
     @Test
-    void missingHeader_returnsSuccessWithoutResponseContentDigest() throws Exception {
-        mockMvc.perform(get(ROOT_ENDPOINT))
+    void missingHeader_returnsSuccessWithResponseContentDigest() throws Exception {
+        mockMvc.perform(get(ROOT_ENDPOINT).header(CONTENT_DIGEST, validEmptyBodyDigest()))
             .andExpect(status().isOk())
-            .andExpect(header().doesNotExist(CONTENT_DIGEST));
+            .andExpect(header().exists(CONTENT_DIGEST));
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -123,7 +123,7 @@ opal:
     content-digest:
       request:
         enforce: ${OPAL_COMMON_CONTENT_DIGEST_REQUEST_ENFORCE:false}
-        auto-generate: ${OPAL_COMMON_CONTENT_DIGEST_REQUEST_AUTO_GENERATE:false}
+        auto-generate: ${OPAL_COMMON_CONTENT_DIGEST_REQUEST_AUTO_GENERATE:true}
       response:
         enforce: ${OPAL_COMMON_CONTENT_DIGEST_RESPONSE_ENFORCE:false}
         algorithm: ${OPAL_COMMON_CONTENT_DIGEST_RESPONSE_ALGORITHM:SHA-512}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-8930


### Change description ###
- Set ```OPAL_COMMON_CONTENT_DIGEST_REQUEST_AUTO_GENERATE``` to ```true``` to fix failing content digest functional tests.


**Does this PR introduce a breaking change?** (check one with "x")

```
[] Yes
[x] No
```
