### PR TITLE
Integration of Opal lib upgrades should be handled manually.

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -45,6 +45,12 @@
       "allowedVersions": "<3.0.0"
     },
     {
+      "description": "opal-common-lib updates are coordinated manually across consuming services",
+      "matchManagers": ["gradle"],
+      "matchPackageNames": ["uk.gov.hmcts:opal-common-lib"],
+      "enabled": false
+    },
+    {
       "description": "Group all Gradle plugins - Minor/Patch",
       "matchManagers": ["gradle"],
       "matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
